### PR TITLE
fix path for assets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 
 		<title>{% if page.include_title %}{{ page.title }} | {% endif %}{{site.title}}</title>
 
-		<link rel="stylesheet" href="{{ site.baseurl }}assets/styles/style.css" />
+		<link rel="stylesheet" href="{{ site.baseurl }}/assets/styles/style.css" />
 
 		<!-- Meta -->
 		<meta content="{{site.title}}" property="og:title" />
@@ -32,7 +32,7 @@
 			{{ content }}
 		</section>
 
-		<script src="{{ site.baseurl }}assets/scripts/stick.js" async></script>
+		<script src="{{ site.baseurl }}/assets/scripts/stick.js" async></script>
 		<script type="text/javascript">
 			WebFontConfig = {
 				google: { families: [ 'Lora:400,400italic:latin', 'Istok+Web:400,400italic,700,700italic:latin' ] }


### PR DESCRIPTION
https://ja.wp-api.org/reference/posts/

Asset link is broken.

fixed.
http://dev-wp-api-docs.azsx.de/reference/posts/