### PR TITLE
Hotfix/assets and dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source "https://rubygems.org"
 gem 'github-pages'
 gem 'pygments.rb'
+gem 'redcarpet'

--- a/_data/attachment.json
+++ b/_data/attachment.json
@@ -21,61 +21,84 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "after": {
               "required": false,
-              "description": "Limit response to resources published after a given ISO8601 compliant date."
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string"
             },
             "author": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to posts assigned to specific authors."
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "author_exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes posts assigned to specific authors."
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "before": {
               "required": false,
-              "description": "Limit response to resources published before a given ISO8601 compliant date."
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "offset": {
               "required": false,
-              "description": "Offset the result set by a specific number of items."
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
             },
             "order": {
               "required": false,
@@ -84,51 +107,70 @@
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
               "default": "date",
               "enum": [
+                "author",
                 "date",
                 "id",
                 "include",
-                "title",
-                "slug"
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
               ],
-              "description": "Sort collection by object attribute."
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             },
             "parent": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to those of particular parent ids."
+              "description": "Limit result set to items with particular parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "parent_exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to all items except those of a particular parent id."
+              "description": "Limit result set to all items except those of a particular parent ID.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "slug": {
               "required": false,
-              "description": "Limit result set to posts with a specific slug."
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "status": {
               "required": false,
               "default": "inherit",
-              "enum": [
-                "inherit",
-                "private",
-                "trash"
-              ],
-              "description": "Limit result set to posts assigned a specific status; can be comma-delimited list of status types."
-            },
-            "filter": {
-              "required": false,
-              "description": "Use WP Query arguments to modify the response; private query vars require appropriate authorization."
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "inherit",
+                  "private",
+                  "trash"
+                ],
+                "type": "string"
+              }
             },
             "media_type": {
               "required": false,
@@ -138,11 +180,13 @@
                 "audio",
                 "application"
               ],
-              "description": "Limit result set to attachments of a particular media type."
+              "description": "Limit result set to attachments of a particular media type.",
+              "type": "string"
             },
             "mime_type": {
               "required": false,
-              "description": "Limit result set to attachments of a particular mime type."
+              "description": "Limit result set to attachments of a particular MIME type.",
+              "type": "string"
             }
           }
         },
@@ -153,19 +197,18 @@
           "args": {
             "date": {
               "required": false,
-              "description": "The date the object was published, in the site's timezone."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published, as GMT."
-            },
-            "password": {
-              "required": false,
-              "description": "A password to protect access to the post."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the object unique to its type."
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
             },
             "status": {
               "required": false,
@@ -176,15 +219,18 @@
                 "pending",
                 "private"
               ],
-              "description": "A named status for the object."
+              "description": "A named status for the object.",
+              "type": "string"
             },
             "title": {
               "required": false,
-              "description": "The title for the object."
+              "description": "The title for the object.",
+              "type": "object"
             },
             "author": {
               "required": false,
-              "description": "The id for the author of the object."
+              "description": "The ID for the author of the object.",
+              "type": "integer"
             },
             "comment_status": {
               "required": false,
@@ -192,7 +238,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not comments are open on the object."
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
             },
             "ping_status": {
               "required": false,
@@ -200,23 +247,38 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not the object can be pinged."
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
             },
             "alt_text": {
               "required": false,
-              "description": "Alternative text to display when resource is not displayed."
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string"
             },
             "caption": {
               "required": false,
-              "description": "The caption for the resource."
+              "description": "The attachment caption.",
+              "type": "object"
             },
             "description": {
               "required": false,
-              "description": "The description for the resource."
+              "description": "The attachment description.",
+              "type": "object"
             },
             "post": {
               "required": false,
-              "description": "The id for the associated post of the resource."
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer"
             }
           }
         }
@@ -314,13 +376,6 @@
             ],
             "readonly": true
           },
-          "password": {
-            "description": "A password to protect access to the post.",
-            "type": "string",
-            "context": [
-              "edit"
-            ]
-          },
           "slug": {
             "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
@@ -341,6 +396,7 @@
               "private"
             ],
             "context": [
+              "view",
               "edit"
             ]
           },
@@ -351,6 +407,22 @@
               "view",
               "edit",
               "embed"
+            ],
+            "readonly": true
+          },
+          "permalink_template": {
+            "description": "Permalink template for the object.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "generated_slug": {
+            "description": "Slug automatically generated from the object title.",
+            "type": "string",
+            "context": [
+              "edit"
             ],
             "readonly": true
           },
@@ -383,7 +455,7 @@
             }
           },
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -415,8 +487,27 @@
               "edit"
             ]
           },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
+          },
+          "template": {
+            "description": "The theme file to use to display the object.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
           "alt_text": {
-            "description": "Alternative text to display when resource is not displayed.",
+            "description": "Alternative text to display when attachment is not displayed.",
             "type": "string",
             "context": [
               "view",
@@ -425,23 +516,61 @@
             ]
           },
           "caption": {
-            "description": "The caption for the resource.",
-            "type": "string",
+            "description": "The attachment caption.",
+            "type": "object",
             "context": [
               "view",
-              "edit"
-            ]
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Caption for the attachment, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML caption for the attachment, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "description": {
-            "description": "The description for the resource.",
-            "type": "string",
+            "description": "The attachment description.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Description for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML description for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "media_type": {
-            "description": "Type of resource.",
+            "description": "Attachment type.",
             "type": "string",
             "enum": [
               "image",
@@ -455,7 +584,7 @@
             "readonly": true
           },
           "mime_type": {
-            "description": "Mime type of resource.",
+            "description": "The attachment MIME type.",
             "type": "string",
             "context": [
               "view",
@@ -465,7 +594,7 @@
             "readonly": true
           },
           "media_details": {
-            "description": "Details about the resource file, specific to its type.",
+            "description": "Details about the media file, specific to its type.",
             "type": "object",
             "context": [
               "view",
@@ -475,7 +604,7 @@
             "readonly": true
           },
           "post": {
-            "description": "The id for the associated post of the resource.",
+            "description": "The ID for the associated post of the attachment.",
             "type": "integer",
             "context": [
               "view",
@@ -483,7 +612,7 @@
             ]
           },
           "source_url": {
-            "description": "URL to the original resource file.",
+            "description": "URL to the original attachment file.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -493,7 +622,37 @@
             ],
             "readonly": true
           }
-        }
+        },
+        "links": [
+          {
+            "rel": "https://api.w.org/action-unfiltered-html",
+            "title": "The current user can post unfiltered HTML markup and JavaScript.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "raw": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-author",
+            "title": "The current user can change the author on this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "author": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ]
       },
       "_links": {
         "self": "https://demo.wp-api.org/wp-json/wp/v2/media"
@@ -515,6 +674,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -523,7 +687,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -534,21 +699,25 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "date": {
               "required": false,
-              "description": "The date the object was published, in the site's timezone."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published, as GMT."
-            },
-            "password": {
-              "required": false,
-              "description": "A password to protect access to the post."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the object unique to its type."
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
             },
             "status": {
               "required": false,
@@ -559,15 +728,18 @@
                 "pending",
                 "private"
               ],
-              "description": "A named status for the object."
+              "description": "A named status for the object.",
+              "type": "string"
             },
             "title": {
               "required": false,
-              "description": "The title for the object."
+              "description": "The title for the object.",
+              "type": "object"
             },
             "author": {
               "required": false,
-              "description": "The id for the author of the object."
+              "description": "The ID for the author of the object.",
+              "type": "integer"
             },
             "comment_status": {
               "required": false,
@@ -575,7 +747,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not comments are open on the object."
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
             },
             "ping_status": {
               "required": false,
@@ -583,23 +756,38 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not the object can be pinged."
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
             },
             "alt_text": {
               "required": false,
-              "description": "Alternative text to display when resource is not displayed."
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string"
             },
             "caption": {
               "required": false,
-              "description": "The caption for the resource."
+              "description": "The attachment caption.",
+              "type": "object"
             },
             "description": {
               "required": false,
-              "description": "The description for the resource."
+              "description": "The attachment description.",
+              "type": "object"
             },
             "post": {
               "required": false,
-              "description": "The id for the associated post of the resource."
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer"
             }
           }
         },
@@ -608,10 +796,16 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Whether to bypass trash and force deletion."
+              "description": "Whether to bypass trash and force deletion.",
+              "type": "boolean"
             }
           }
         }
@@ -709,13 +903,6 @@
             ],
             "readonly": true
           },
-          "password": {
-            "description": "A password to protect access to the post.",
-            "type": "string",
-            "context": [
-              "edit"
-            ]
-          },
           "slug": {
             "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
@@ -736,6 +923,7 @@
               "private"
             ],
             "context": [
+              "view",
               "edit"
             ]
           },
@@ -746,6 +934,22 @@
               "view",
               "edit",
               "embed"
+            ],
+            "readonly": true
+          },
+          "permalink_template": {
+            "description": "Permalink template for the object.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "generated_slug": {
+            "description": "Slug automatically generated from the object title.",
+            "type": "string",
+            "context": [
+              "edit"
             ],
             "readonly": true
           },
@@ -778,7 +982,7 @@
             }
           },
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -810,8 +1014,27 @@
               "edit"
             ]
           },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
+          },
+          "template": {
+            "description": "The theme file to use to display the object.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
           "alt_text": {
-            "description": "Alternative text to display when resource is not displayed.",
+            "description": "Alternative text to display when attachment is not displayed.",
             "type": "string",
             "context": [
               "view",
@@ -820,23 +1043,61 @@
             ]
           },
           "caption": {
-            "description": "The caption for the resource.",
-            "type": "string",
+            "description": "The attachment caption.",
+            "type": "object",
             "context": [
               "view",
-              "edit"
-            ]
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Caption for the attachment, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML caption for the attachment, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "description": {
-            "description": "The description for the resource.",
-            "type": "string",
+            "description": "The attachment description.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Description for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML description for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "media_type": {
-            "description": "Type of resource.",
+            "description": "Attachment type.",
             "type": "string",
             "enum": [
               "image",
@@ -850,7 +1111,7 @@
             "readonly": true
           },
           "mime_type": {
-            "description": "Mime type of resource.",
+            "description": "The attachment MIME type.",
             "type": "string",
             "context": [
               "view",
@@ -860,7 +1121,7 @@
             "readonly": true
           },
           "media_details": {
-            "description": "Details about the resource file, specific to its type.",
+            "description": "Details about the media file, specific to its type.",
             "type": "object",
             "context": [
               "view",
@@ -870,7 +1131,7 @@
             "readonly": true
           },
           "post": {
-            "description": "The id for the associated post of the resource.",
+            "description": "The ID for the associated post of the attachment.",
             "type": "integer",
             "context": [
               "view",
@@ -878,7 +1139,7 @@
             ]
           },
           "source_url": {
-            "description": "URL to the original resource file.",
+            "description": "URL to the original attachment file.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -888,7 +1149,37 @@
             ],
             "readonly": true
           }
-        }
+        },
+        "links": [
+          {
+            "rel": "https://api.w.org/action-unfiltered-html",
+            "title": "The current user can post unfiltered HTML markup and JavaScript.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "raw": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-author",
+            "title": "The current user can change the author on this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "author": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ]
       },
       "nicename": "/wp/v2/media/&lt;id&gt;"
     }
@@ -986,13 +1277,6 @@
         ],
         "readonly": true
       },
-      "password": {
-        "description": "A password to protect access to the post.",
-        "type": "string",
-        "context": [
-          "edit"
-        ]
-      },
       "slug": {
         "description": "An alphanumeric identifier for the object unique to its type.",
         "type": "string",
@@ -1013,6 +1297,7 @@
           "private"
         ],
         "context": [
+          "view",
           "edit"
         ]
       },
@@ -1023,6 +1308,22 @@
           "view",
           "edit",
           "embed"
+        ],
+        "readonly": true
+      },
+      "permalink_template": {
+        "description": "Permalink template for the object.",
+        "type": "string",
+        "context": [
+          "edit"
+        ],
+        "readonly": true
+      },
+      "generated_slug": {
+        "description": "Slug automatically generated from the object title.",
+        "type": "string",
+        "context": [
+          "edit"
         ],
         "readonly": true
       },
@@ -1055,7 +1356,7 @@
         }
       },
       "author": {
-        "description": "The id for the author of the object.",
+        "description": "The ID for the author of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -1087,8 +1388,27 @@
           "edit"
         ]
       },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
+        ]
+      },
+      "template": {
+        "description": "The theme file to use to display the object.",
+        "type": "string",
+        "context": [
+          "view",
+          "edit"
+        ]
+      },
       "alt_text": {
-        "description": "Alternative text to display when resource is not displayed.",
+        "description": "Alternative text to display when attachment is not displayed.",
         "type": "string",
         "context": [
           "view",
@@ -1097,23 +1417,61 @@
         ]
       },
       "caption": {
-        "description": "The caption for the resource.",
-        "type": "string",
+        "description": "The attachment caption.",
+        "type": "object",
         "context": [
           "view",
-          "edit"
-        ]
+          "edit",
+          "embed"
+        ],
+        "properties": {
+          "raw": {
+            "description": "Caption for the attachment, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML caption for the attachment, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       },
       "description": {
-        "description": "The description for the resource.",
-        "type": "string",
+        "description": "The attachment description.",
+        "type": "object",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Description for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML description for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
       },
       "media_type": {
-        "description": "Type of resource.",
+        "description": "Attachment type.",
         "type": "string",
         "enum": [
           "image",
@@ -1127,7 +1485,7 @@
         "readonly": true
       },
       "mime_type": {
-        "description": "Mime type of resource.",
+        "description": "The attachment MIME type.",
         "type": "string",
         "context": [
           "view",
@@ -1137,7 +1495,7 @@
         "readonly": true
       },
       "media_details": {
-        "description": "Details about the resource file, specific to its type.",
+        "description": "Details about the media file, specific to its type.",
         "type": "object",
         "context": [
           "view",
@@ -1147,7 +1505,7 @@
         "readonly": true
       },
       "post": {
-        "description": "The id for the associated post of the resource.",
+        "description": "The ID for the associated post of the attachment.",
         "type": "integer",
         "context": [
           "view",
@@ -1155,7 +1513,7 @@
         ]
       },
       "source_url": {
-        "description": "URL to the original resource file.",
+        "description": "URL to the original attachment file.",
         "type": "string",
         "format": "uri",
         "context": [
@@ -1165,6 +1523,36 @@
         ],
         "readonly": true
       }
-    }
+    },
+    "links": [
+      {
+        "rel": "https://api.w.org/action-unfiltered-html",
+        "title": "The current user can post unfiltered HTML markup and JavaScript.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "content": {
+              "raw": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-assign-author",
+        "title": "The current user can change the author on this post.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/media/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/_data/category.json
+++ b/_data/category.json
@@ -21,35 +21,47 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "order": {
               "required": false,
@@ -58,7 +70,8 @@
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
@@ -68,28 +81,37 @@
                 "include",
                 "name",
                 "slug",
+                "include_slugs",
                 "term_group",
                 "description",
                 "count"
               ],
-              "description": "Sort collection by resource attribute."
+              "description": "Sort collection by term attribute.",
+              "type": "string"
             },
             "hide_empty": {
               "required": false,
               "default": false,
-              "description": "Whether to hide resources not assigned to any posts."
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean"
             },
             "parent": {
               "required": false,
-              "description": "Limit result set to resources assigned to a specific parent."
+              "description": "Limit result set to terms assigned to a specific parent.",
+              "type": "integer"
             },
             "post": {
               "required": false,
-              "description": "Limit result set to resources assigned to a specific post."
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer"
             },
             "slug": {
               "required": false,
-              "description": "Limit result set to resources with a specific slug."
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
@@ -100,19 +122,28 @@
           "args": {
             "description": {
               "required": false,
-              "description": "HTML description of the resource."
+              "description": "HTML description of the term.",
+              "type": "string"
             },
             "name": {
               "required": true,
-              "description": "HTML title for the resource."
+              "description": "HTML title for the term.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource unique to its type."
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string"
             },
             "parent": {
               "required": false,
-              "description": "The id for the parent of the resource."
+              "description": "The parent term ID.",
+              "type": "integer"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         }
@@ -123,7 +154,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -133,7 +164,7 @@
             "readonly": true
           },
           "count": {
-            "description": "Number of published posts for the resource.",
+            "description": "Number of published posts for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -142,7 +173,7 @@
             "readonly": true
           },
           "description": {
-            "description": "HTML description of the resource.",
+            "description": "HTML description of the term.",
             "type": "string",
             "context": [
               "view",
@@ -150,7 +181,7 @@
             ]
           },
           "link": {
-            "description": "URL to the resource.",
+            "description": "URL of the term.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -161,7 +192,7 @@
             "readonly": true
           },
           "name": {
-            "description": "HTML title for the resource.",
+            "description": "HTML title for the term.",
             "type": "string",
             "context": [
               "view",
@@ -171,7 +202,7 @@
             "required": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource unique to its type.",
+            "description": "An alphanumeric identifier for the term unique to its type.",
             "type": "string",
             "context": [
               "view",
@@ -180,7 +211,7 @@
             ]
           },
           "taxonomy": {
-            "description": "Type attribution for the resource.",
+            "description": "Type attribution for the term.",
             "type": "string",
             "enum": [
               "category",
@@ -197,11 +228,22 @@
             "readonly": true
           },
           "parent": {
-            "description": "The id for the parent of the resource.",
+            "description": "The parent term ID.",
             "type": "integer",
             "context": [
               "view",
               "edit"
+            ]
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
             ]
           }
         }
@@ -226,6 +268,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -234,7 +281,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -245,21 +293,35 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "description": {
               "required": false,
-              "description": "HTML description of the resource."
+              "description": "HTML description of the term.",
+              "type": "string"
             },
             "name": {
               "required": false,
-              "description": "HTML title for the resource."
+              "description": "HTML title for the term.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource unique to its type."
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string"
             },
             "parent": {
               "required": false,
-              "description": "The id for the parent of the resource."
+              "description": "The parent term ID.",
+              "type": "integer"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         },
@@ -268,10 +330,16 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Required to be true, as resource does not support trashing."
+              "description": "Required to be true, as terms do not support trashing.",
+              "type": "boolean"
             }
           }
         }
@@ -282,7 +350,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -292,7 +360,7 @@
             "readonly": true
           },
           "count": {
-            "description": "Number of published posts for the resource.",
+            "description": "Number of published posts for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -301,7 +369,7 @@
             "readonly": true
           },
           "description": {
-            "description": "HTML description of the resource.",
+            "description": "HTML description of the term.",
             "type": "string",
             "context": [
               "view",
@@ -309,7 +377,7 @@
             ]
           },
           "link": {
-            "description": "URL to the resource.",
+            "description": "URL of the term.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -320,7 +388,7 @@
             "readonly": true
           },
           "name": {
-            "description": "HTML title for the resource.",
+            "description": "HTML title for the term.",
             "type": "string",
             "context": [
               "view",
@@ -330,7 +398,7 @@
             "required": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource unique to its type.",
+            "description": "An alphanumeric identifier for the term unique to its type.",
             "type": "string",
             "context": [
               "view",
@@ -339,7 +407,7 @@
             ]
           },
           "taxonomy": {
-            "description": "Type attribution for the resource.",
+            "description": "Type attribution for the term.",
             "type": "string",
             "enum": [
               "category",
@@ -356,11 +424,22 @@
             "readonly": true
           },
           "parent": {
-            "description": "The id for the parent of the resource.",
+            "description": "The parent term ID.",
             "type": "integer",
             "context": [
               "view",
               "edit"
+            ]
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
             ]
           }
         }
@@ -374,7 +453,7 @@
     "type": "object",
     "properties": {
       "id": {
-        "description": "Unique identifier for the resource.",
+        "description": "Unique identifier for the term.",
         "type": "integer",
         "context": [
           "view",
@@ -384,7 +463,7 @@
         "readonly": true
       },
       "count": {
-        "description": "Number of published posts for the resource.",
+        "description": "Number of published posts for the term.",
         "type": "integer",
         "context": [
           "view",
@@ -393,7 +472,7 @@
         "readonly": true
       },
       "description": {
-        "description": "HTML description of the resource.",
+        "description": "HTML description of the term.",
         "type": "string",
         "context": [
           "view",
@@ -401,7 +480,7 @@
         ]
       },
       "link": {
-        "description": "URL to the resource.",
+        "description": "URL of the term.",
         "type": "string",
         "format": "uri",
         "context": [
@@ -412,7 +491,7 @@
         "readonly": true
       },
       "name": {
-        "description": "HTML title for the resource.",
+        "description": "HTML title for the term.",
         "type": "string",
         "context": [
           "view",
@@ -422,7 +501,7 @@
         "required": true
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource unique to its type.",
+        "description": "An alphanumeric identifier for the term unique to its type.",
         "type": "string",
         "context": [
           "view",
@@ -431,7 +510,7 @@
         ]
       },
       "taxonomy": {
-        "description": "Type attribution for the resource.",
+        "description": "Type attribution for the term.",
         "type": "string",
         "enum": [
           "category",
@@ -448,11 +527,22 @@
         "readonly": true
       },
       "parent": {
-        "description": "The id for the parent of the resource.",
+        "description": "The parent term ID.",
         "type": "integer",
         "context": [
           "view",
           "edit"
+        ]
+      },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
         ]
       }
     }

--- a/_data/comment.json
+++ b/_data/comment.json
@@ -21,72 +21,93 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "after": {
               "required": false,
-              "description": "Limit response to resources published after a given ISO8601 compliant date."
+              "description": "Limit response to comments published after a given ISO8601 compliant date.",
+              "type": "string"
             },
             "author": {
               "required": false,
-              "description": "Limit result set to comments assigned to specific user ids. Requires authorization."
+              "description": "Limit result set to comments assigned to specific user IDs. Requires authorization.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "author_exclude": {
               "required": false,
-              "description": "Ensure result set excludes comments assigned to specific user ids. Requires authorization."
+              "description": "Ensure result set excludes comments assigned to specific user IDs. Requires authorization.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "author_email": {
               "required": false,
-              "description": "Limit result set to that from a specific author email. Requires authorization."
+              "description": "Limit result set to that from a specific author email. Requires authorization.",
+              "type": "string"
             },
             "before": {
               "required": false,
-              "description": "Limit response to resources published before a given ISO8601 compliant date."
+              "description": "Limit response to comments published before a given ISO8601 compliant date.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
-            },
-            "karma": {
-              "required": false,
-              "description": "Limit result set to that of a particular comment karma. Requires authorization."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "offset": {
               "required": false,
-              "description": "Offset the result set by a specific number of comments."
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
             },
             "order": {
               "required": false,
-              "default": "asc",
+              "default": "desc",
               "enum": [
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
@@ -100,38 +121,58 @@
                 "parent",
                 "type"
               ],
-              "description": "Sort collection by object attribute."
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             },
             "parent": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to resources of specific parent ids."
+              "description": "Limit result set to comments of specific parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "parent_exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific parent ids."
+              "description": "Ensure result set excludes specific parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "post": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to resources assigned to specific post ids."
+              "description": "Limit result set to comments assigned to specific post IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "status": {
               "required": false,
               "default": "approve",
-              "description": "Limit result set to comments assigned a specific status. Requires authorization."
+              "description": "Limit result set to comments assigned a specific status. Requires authorization.",
+              "type": "string"
             },
             "type": {
               "required": false,
               "default": "comment",
-              "description": "Limit result set to comments assigned a specific type. Requires authorization."
+              "description": "Limit result set to comments assigned a specific type. Requires authorization.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "The password for the post if it is password protected.",
+              "type": "string"
             }
           }
         },
@@ -142,61 +183,70 @@
           "args": {
             "author": {
               "required": false,
-              "description": "The id of the user object, if author was a user."
+              "description": "The ID of the user object, if author was a user.",
+              "type": "integer"
             },
             "author_email": {
               "required": false,
-              "description": "Email address for the object author."
+              "description": "Email address for the object author.",
+              "type": "string"
             },
             "author_ip": {
               "required": false,
-              "default": "127.0.0.1",
-              "description": "IP address for the object author."
+              "description": "IP address for the object author.",
+              "type": "string"
             },
             "author_name": {
               "required": false,
-              "default": "",
-              "description": "Display name for the object author."
+              "description": "Display name for the object author.",
+              "type": "string"
             },
             "author_url": {
               "required": false,
-              "description": "URL for the object author."
+              "description": "URL for the object author.",
+              "type": "string"
+            },
+            "author_user_agent": {
+              "required": false,
+              "description": "User agent for the object author.",
+              "type": "string"
             },
             "content": {
               "required": false,
-              "default": "",
-              "description": "The content for the object."
+              "description": "The content for the object.",
+              "type": "object"
             },
             "date": {
               "required": false,
-              "description": "The date the object was published."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published as GMT."
-            },
-            "karma": {
-              "required": false,
-              "description": "Karma for the object."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "parent": {
               "required": false,
               "default": 0,
-              "description": "The id for the parent of the object."
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
             },
             "post": {
               "required": false,
               "default": 0,
-              "description": "The id of the associated post object."
+              "description": "The ID of the associated post object.",
+              "type": "integer"
             },
             "status": {
               "required": false,
-              "description": "State of the object."
+              "description": "State of the object.",
+              "type": "string"
             },
-            "type": {
+            "meta": {
               "required": false,
-              "default": "",
-              "description": "Type of Comment for the object."
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         }
@@ -217,7 +267,7 @@
             "readonly": true
           },
           "author": {
-            "description": "The id of the user object, if author was a user.",
+            "description": "The ID of the user object, if author was a user.",
             "type": "integer",
             "context": [
               "view",
@@ -236,7 +286,7 @@
           "author_ip": {
             "description": "IP address for the object author.",
             "type": "string",
-            "format": "ipv4",
+            "format": "ip",
             "context": [
               "edit"
             ]
@@ -265,8 +315,7 @@
             "type": "string",
             "context": [
               "edit"
-            ],
-            "readonly": true
+            ]
           },
           "content": {
             "description": "The content for the object.",
@@ -291,12 +340,13 @@
                   "view",
                   "edit",
                   "embed"
-                ]
+                ],
+                "readonly": true
               }
             }
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -306,18 +356,11 @@
             ]
           },
           "date_gmt": {
-            "description": "The date the object was published as GMT.",
+            "description": "The date the object was published, as GMT.",
             "type": "string",
             "format": "date-time",
             "context": [
               "view",
-              "edit"
-            ]
-          },
-          "karma": {
-            "description": "Karma for the object.",
-            "type": "integer",
-            "context": [
               "edit"
             ]
           },
@@ -333,21 +376,23 @@
             "readonly": true
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "default": 0
           },
           "post": {
-            "description": "The id of the associated post object.",
+            "description": "The ID of the associated post object.",
             "type": "integer",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "default": 0
           },
           "status": {
             "description": "State of the object.",
@@ -364,7 +409,8 @@
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "readonly": true
           },
           "author_avatar_urls": {
             "description": "Avatar URLs for the object author.",
@@ -407,6 +453,17 @@
                 ]
               }
             }
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
@@ -430,6 +487,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -438,7 +500,13 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "The password for the parent post of the comment (if the post is password protected).",
+              "type": "string"
             }
           }
         },
@@ -449,57 +517,75 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "author": {
               "required": false,
-              "description": "The id of the user object, if author was a user."
+              "description": "The ID of the user object, if author was a user.",
+              "type": "integer"
             },
             "author_email": {
               "required": false,
-              "description": "Email address for the object author."
+              "description": "Email address for the object author.",
+              "type": "string"
             },
             "author_ip": {
               "required": false,
-              "description": "IP address for the object author."
+              "description": "IP address for the object author.",
+              "type": "string"
             },
             "author_name": {
               "required": false,
-              "description": "Display name for the object author."
+              "description": "Display name for the object author.",
+              "type": "string"
             },
             "author_url": {
               "required": false,
-              "description": "URL for the object author."
+              "description": "URL for the object author.",
+              "type": "string"
+            },
+            "author_user_agent": {
+              "required": false,
+              "description": "User agent for the object author.",
+              "type": "string"
             },
             "content": {
               "required": false,
-              "description": "The content for the object."
+              "description": "The content for the object.",
+              "type": "object"
             },
             "date": {
               "required": false,
-              "description": "The date the object was published."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published as GMT."
-            },
-            "karma": {
-              "required": false,
-              "description": "Karma for the object."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "parent": {
               "required": false,
-              "description": "The id for the parent of the object."
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
             },
             "post": {
               "required": false,
-              "description": "The id of the associated post object."
+              "description": "The ID of the associated post object.",
+              "type": "integer"
             },
             "status": {
               "required": false,
-              "description": "State of the object."
+              "description": "State of the object.",
+              "type": "string"
             },
-            "type": {
+            "meta": {
               "required": false,
-              "description": "Type of Comment for the object."
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         },
@@ -508,10 +594,21 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Whether to bypass trash and force deletion."
+              "description": "Whether to bypass trash and force deletion.",
+              "type": "boolean"
+            },
+            "password": {
+              "required": false,
+              "description": "The password for the parent post of the comment (if the post is password protected).",
+              "type": "string"
             }
           }
         }
@@ -532,7 +629,7 @@
             "readonly": true
           },
           "author": {
-            "description": "The id of the user object, if author was a user.",
+            "description": "The ID of the user object, if author was a user.",
             "type": "integer",
             "context": [
               "view",
@@ -551,7 +648,7 @@
           "author_ip": {
             "description": "IP address for the object author.",
             "type": "string",
-            "format": "ipv4",
+            "format": "ip",
             "context": [
               "edit"
             ]
@@ -580,8 +677,7 @@
             "type": "string",
             "context": [
               "edit"
-            ],
-            "readonly": true
+            ]
           },
           "content": {
             "description": "The content for the object.",
@@ -606,12 +702,13 @@
                   "view",
                   "edit",
                   "embed"
-                ]
+                ],
+                "readonly": true
               }
             }
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -621,18 +718,11 @@
             ]
           },
           "date_gmt": {
-            "description": "The date the object was published as GMT.",
+            "description": "The date the object was published, as GMT.",
             "type": "string",
             "format": "date-time",
             "context": [
               "view",
-              "edit"
-            ]
-          },
-          "karma": {
-            "description": "Karma for the object.",
-            "type": "integer",
-            "context": [
               "edit"
             ]
           },
@@ -648,21 +738,23 @@
             "readonly": true
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "default": 0
           },
           "post": {
-            "description": "The id of the associated post object.",
+            "description": "The ID of the associated post object.",
             "type": "integer",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "default": 0
           },
           "status": {
             "description": "State of the object.",
@@ -679,7 +771,8 @@
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "readonly": true
           },
           "author_avatar_urls": {
             "description": "Avatar URLs for the object author.",
@@ -722,6 +815,17 @@
                 ]
               }
             }
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
@@ -744,7 +848,7 @@
         "readonly": true
       },
       "author": {
-        "description": "The id of the user object, if author was a user.",
+        "description": "The ID of the user object, if author was a user.",
         "type": "integer",
         "context": [
           "view",
@@ -763,7 +867,7 @@
       "author_ip": {
         "description": "IP address for the object author.",
         "type": "string",
-        "format": "ipv4",
+        "format": "ip",
         "context": [
           "edit"
         ]
@@ -792,8 +896,7 @@
         "type": "string",
         "context": [
           "edit"
-        ],
-        "readonly": true
+        ]
       },
       "content": {
         "description": "The content for the object.",
@@ -818,12 +921,13 @@
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "readonly": true
           }
         }
       },
       "date": {
-        "description": "The date the object was published.",
+        "description": "The date the object was published, in the site's timezone.",
         "type": "string",
         "format": "date-time",
         "context": [
@@ -833,18 +937,11 @@
         ]
       },
       "date_gmt": {
-        "description": "The date the object was published as GMT.",
+        "description": "The date the object was published, as GMT.",
         "type": "string",
         "format": "date-time",
         "context": [
           "view",
-          "edit"
-        ]
-      },
-      "karma": {
-        "description": "Karma for the object.",
-        "type": "integer",
-        "context": [
           "edit"
         ]
       },
@@ -860,21 +957,23 @@
         "readonly": true
       },
       "parent": {
-        "description": "The id for the parent of the object.",
+        "description": "The ID for the parent of the object.",
         "type": "integer",
         "context": [
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "default": 0
       },
       "post": {
-        "description": "The id of the associated post object.",
+        "description": "The ID of the associated post object.",
         "type": "integer",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "default": 0
       },
       "status": {
         "description": "State of the object.",
@@ -891,7 +990,8 @@
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "readonly": true
       },
       "author_avatar_urls": {
         "description": "Avatar URLs for the object author.",
@@ -934,6 +1034,17 @@
             ]
           }
         }
+      },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
+        ]
       }
     }
   }

--- a/_data/page-revision.json
+++ b/_data/page-revision.json
@@ -12,6 +12,11 @@
             "GET"
           ],
           "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -20,7 +25,76 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "page": {
+              "required": false,
+              "default": 1,
+              "description": "Current page of the collection.",
+              "type": "integer"
+            },
+            "per_page": {
+              "required": false,
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
+            },
+            "search": {
+              "required": false,
+              "description": "Limit results to those matching a string.",
+              "type": "string"
+            },
+            "exclude": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "include": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "offset": {
+              "required": false,
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
+            },
+            "order": {
+              "required": false,
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
+            },
+            "orderby": {
+              "required": false,
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             }
           }
         }
@@ -31,7 +105,7 @@
         "type": "object",
         "properties": {
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -40,7 +114,7 @@
             ]
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -59,12 +133,32 @@
             ]
           },
           "guid": {
-            "description": "GUID for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "id": {
             "description": "Unique identifier for the object.",
@@ -76,7 +170,7 @@
             ]
           },
           "modified": {
-            "description": "The date the object was last modified.",
+            "description": "The date the object was last modified, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -94,7 +188,7 @@
             ]
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -112,30 +206,114 @@
             ]
           },
           "title": {
-            "description": "Title for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The title for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "content": {
-            "description": "Content for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The content for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "excerpt": {
-            "description": "Excerpt for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The excerpt for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           }
         }
       },
@@ -153,6 +331,16 @@
             "GET"
           ],
           "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -161,7 +349,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -169,9 +358,24 @@
           "methods": [
             "DELETE"
           ],
-          "args": [
-
-          ]
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
+            "force": {
+              "required": false,
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "type": "boolean"
+            }
+          }
         }
       ],
       "schema": {
@@ -180,7 +384,7 @@
         "type": "object",
         "properties": {
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -189,7 +393,7 @@
             ]
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -208,12 +412,32 @@
             ]
           },
           "guid": {
-            "description": "GUID for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "id": {
             "description": "Unique identifier for the object.",
@@ -225,7 +449,7 @@
             ]
           },
           "modified": {
-            "description": "The date the object was last modified.",
+            "description": "The date the object was last modified, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -243,7 +467,7 @@
             ]
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -261,34 +485,744 @@
             ]
           },
           "title": {
-            "description": "Title for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          }
+        }
+      },
+      "nicename": "/wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;"
+    },
+    "/wp/v2/pages/<id>/autosaves": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "date": {
+              "required": false,
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
+            },
+            "date_gmt": {
+              "required": false,
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
+            },
+            "slug": {
+              "required": false,
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
+            },
+            "status": {
+              "required": false,
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private"
+              ],
+              "description": "A named status for the object.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string"
+            },
+            "title": {
+              "required": false,
+              "description": "The title for the object.",
+              "type": "object"
+            },
+            "content": {
+              "required": false,
+              "description": "The content for the object.",
+              "type": "object"
+            },
+            "author": {
+              "required": false,
+              "description": "The ID for the author of the object.",
+              "type": "integer"
+            },
+            "excerpt": {
+              "required": false,
+              "description": "The excerpt for the object.",
+              "type": "object"
+            },
+            "featured_media": {
+              "required": false,
+              "description": "The ID of the featured media for the object.",
+              "type": "integer"
+            },
+            "comment_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
+            },
+            "ping_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
+            },
+            "menu_order": {
+              "required": false,
+              "description": "The order of the object in relation to other object of its type.",
+              "type": "integer"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "page-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
             "context": [
               "view",
               "edit",
               "embed"
             ]
           },
-          "content": {
-            "description": "Content for the object, as it exists in the database.",
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
             "context": [
               "view",
               "edit"
             ]
           },
-          "excerpt": {
-            "description": "Excerpt for the object, as it exists in the database.",
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
             "context": [
               "view",
               "edit",
               "embed"
             ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
           }
         }
       },
-      "nicename": "/wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;"
+      "nicename": "/wp/v2/pages/&lt;id&gt;/autosaves"
+    },
+    "/wp/v2/pages/<parent>/autosaves/<id>": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "The ID for the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "page-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "nicename": "/wp/v2/pages/&lt;parent&gt;/autosaves/&lt;id&gt;"
     }
   },
   "schema": {
@@ -297,7 +1231,7 @@
     "type": "object",
     "properties": {
       "author": {
-        "description": "The id for the author of the object.",
+        "description": "The ID for the author of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -306,7 +1240,7 @@
         ]
       },
       "date": {
-        "description": "The date the object was published.",
+        "description": "The date the object was published, in the site's timezone.",
         "type": "string",
         "format": "date-time",
         "context": [
@@ -325,12 +1259,32 @@
         ]
       },
       "guid": {
-        "description": "GUID for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The globally unique identifier for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "readonly": true,
+        "properties": {
+          "raw": {
+            "description": "GUID for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "rendered": {
+            "description": "GUID for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
       },
       "id": {
         "description": "Unique identifier for the object.",
@@ -342,7 +1296,7 @@
         ]
       },
       "modified": {
-        "description": "The date the object was last modified.",
+        "description": "The date the object was last modified, in the site's timezone.",
         "type": "string",
         "format": "date-time",
         "context": [
@@ -360,7 +1314,7 @@
         ]
       },
       "parent": {
-        "description": "The id for the parent of the object.",
+        "description": "The ID for the parent of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -378,30 +1332,114 @@
         ]
       },
       "title": {
-        "description": "Title for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The title for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Title for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML title for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       },
       "content": {
-        "description": "Content for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The content for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Content for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML content for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "block_version": {
+            "description": "Version of the content block format used by the object.",
+            "type": "integer",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the content is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       },
       "excerpt": {
-        "description": "Excerpt for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The excerpt for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Excerpt for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML excerpt for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the excerpt is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       }
     }
   }

--- a/_data/post-revision.json
+++ b/_data/post-revision.json
@@ -12,6 +12,11 @@
             "GET"
           ],
           "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -20,7 +25,76 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "page": {
+              "required": false,
+              "default": 1,
+              "description": "Current page of the collection.",
+              "type": "integer"
+            },
+            "per_page": {
+              "required": false,
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
+            },
+            "search": {
+              "required": false,
+              "description": "Limit results to those matching a string.",
+              "type": "string"
+            },
+            "exclude": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "include": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "offset": {
+              "required": false,
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
+            },
+            "order": {
+              "required": false,
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
+            },
+            "orderby": {
+              "required": false,
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             }
           }
         }
@@ -31,7 +105,7 @@
         "type": "object",
         "properties": {
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -40,7 +114,7 @@
             ]
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -59,12 +133,32 @@
             ]
           },
           "guid": {
-            "description": "GUID for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "id": {
             "description": "Unique identifier for the object.",
@@ -76,7 +170,7 @@
             ]
           },
           "modified": {
-            "description": "The date the object was last modified.",
+            "description": "The date the object was last modified, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -94,7 +188,7 @@
             ]
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -112,30 +206,114 @@
             ]
           },
           "title": {
-            "description": "Title for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The title for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "content": {
-            "description": "Content for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The content for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           },
           "excerpt": {
-            "description": "Excerpt for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The excerpt for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit",
               "embed"
-            ]
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
           }
         }
       },
@@ -153,6 +331,16 @@
             "GET"
           ],
           "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -161,7 +349,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -169,9 +358,24 @@
           "methods": [
             "DELETE"
           ],
-          "args": [
-
-          ]
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
+            "force": {
+              "required": false,
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "type": "boolean"
+            }
+          }
         }
       ],
       "schema": {
@@ -180,7 +384,7 @@
         "type": "object",
         "properties": {
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -189,7 +393,7 @@
             ]
           },
           "date": {
-            "description": "The date the object was published.",
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -208,12 +412,32 @@
             ]
           },
           "guid": {
-            "description": "GUID for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
             "context": [
               "view",
               "edit"
-            ]
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
           },
           "id": {
             "description": "Unique identifier for the object.",
@@ -225,7 +449,7 @@
             ]
           },
           "modified": {
-            "description": "The date the object was last modified.",
+            "description": "The date the object was last modified, in the site's timezone.",
             "type": "string",
             "format": "date-time",
             "context": [
@@ -243,7 +467,7 @@
             ]
           },
           "parent": {
-            "description": "The id for the parent of the object.",
+            "description": "The ID for the parent of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -261,34 +485,777 @@
             ]
           },
           "title": {
-            "description": "Title for the object, as it exists in the database.",
-            "type": "string",
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          }
+        }
+      },
+      "nicename": "/wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;"
+    },
+    "/wp/v2/posts/<id>/autosaves": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "date": {
+              "required": false,
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
+            },
+            "date_gmt": {
+              "required": false,
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
+            },
+            "slug": {
+              "required": false,
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
+            },
+            "status": {
+              "required": false,
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private"
+              ],
+              "description": "A named status for the object.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string"
+            },
+            "title": {
+              "required": false,
+              "description": "The title for the object.",
+              "type": "object"
+            },
+            "content": {
+              "required": false,
+              "description": "The content for the object.",
+              "type": "object"
+            },
+            "author": {
+              "required": false,
+              "description": "The ID for the author of the object.",
+              "type": "integer"
+            },
+            "excerpt": {
+              "required": false,
+              "description": "The excerpt for the object.",
+              "type": "object"
+            },
+            "featured_media": {
+              "required": false,
+              "description": "The ID of the featured media for the object.",
+              "type": "integer"
+            },
+            "comment_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
+            },
+            "ping_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
+            },
+            "format": {
+              "required": false,
+              "enum": [
+                "standard",
+                "aside",
+                "chat",
+                "gallery",
+                "link",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio"
+              ],
+              "description": "The format for the object.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
+            },
+            "sticky": {
+              "required": false,
+              "description": "Whether or not the object should be treated as sticky.",
+              "type": "boolean"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
+            },
+            "categories": {
+              "required": false,
+              "description": "The terms assigned to the object in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "tags": {
+              "required": false,
+              "description": "The terms assigned to the object in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "post-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
             "context": [
               "view",
               "edit",
               "embed"
             ]
           },
-          "content": {
-            "description": "Content for the object, as it exists in the database.",
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
             "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
             "context": [
               "view",
               "edit"
             ]
           },
-          "excerpt": {
-            "description": "Excerpt for the object, as it exists in the database.",
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
             "context": [
               "view",
               "edit",
               "embed"
             ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
           }
         }
       },
-      "nicename": "/wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;"
+      "nicename": "/wp/v2/posts/&lt;id&gt;/autosaves"
+    },
+    "/wp/v2/posts/<parent>/autosaves/<id>": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "The ID for the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "post-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "excerpt": {
+            "description": "The excerpt for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Excerpt for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML excerpt for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "nicename": "/wp/v2/posts/&lt;parent&gt;/autosaves/&lt;id&gt;"
     }
   },
   "schema": {
@@ -297,7 +1264,7 @@
     "type": "object",
     "properties": {
       "author": {
-        "description": "The id for the author of the object.",
+        "description": "The ID for the author of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -306,7 +1273,7 @@
         ]
       },
       "date": {
-        "description": "The date the object was published.",
+        "description": "The date the object was published, in the site's timezone.",
         "type": "string",
         "format": "date-time",
         "context": [
@@ -325,12 +1292,32 @@
         ]
       },
       "guid": {
-        "description": "GUID for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The globally unique identifier for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "readonly": true,
+        "properties": {
+          "raw": {
+            "description": "GUID for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "rendered": {
+            "description": "GUID for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
       },
       "id": {
         "description": "Unique identifier for the object.",
@@ -342,7 +1329,7 @@
         ]
       },
       "modified": {
-        "description": "The date the object was last modified.",
+        "description": "The date the object was last modified, in the site's timezone.",
         "type": "string",
         "format": "date-time",
         "context": [
@@ -360,7 +1347,7 @@
         ]
       },
       "parent": {
-        "description": "The id for the parent of the object.",
+        "description": "The ID for the parent of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -378,30 +1365,114 @@
         ]
       },
       "title": {
-        "description": "Title for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The title for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Title for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML title for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       },
       "content": {
-        "description": "Content for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The content for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Content for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML content for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "block_version": {
+            "description": "Version of the content block format used by the object.",
+            "type": "integer",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the content is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       },
       "excerpt": {
-        "description": "Excerpt for the object, as it exists in the database.",
-        "type": "string",
+        "description": "The excerpt for the object.",
+        "type": "object",
         "context": [
           "view",
           "edit",
           "embed"
-        ]
+        ],
+        "properties": {
+          "raw": {
+            "description": "Excerpt for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML excerpt for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the excerpt is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
       }
     }
   }

--- a/_data/post.json
+++ b/_data/post.json
@@ -21,61 +21,84 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "after": {
               "required": false,
-              "description": "Limit response to resources published after a given ISO8601 compliant date."
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string"
             },
             "author": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to posts assigned to specific authors."
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "author_exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes posts assigned to specific authors."
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "before": {
               "required": false,
-              "description": "Limit response to resources published before a given ISO8601 compliant date."
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "offset": {
               "required": false,
-              "description": "Offset the result set by a specific number of items."
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
             },
             "order": {
               "required": false,
@@ -84,46 +107,107 @@
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
               "default": "date",
               "enum": [
+                "author",
                 "date",
                 "id",
                 "include",
-                "title",
-                "slug"
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
               ],
-              "description": "Sort collection by object attribute."
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "Limit result set to posts with a specific slug."
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "status": {
               "required": false,
               "default": "publish",
-              "description": "Limit result set to posts assigned a specific status; can be comma-delimited list of status types."
-            },
-            "filter": {
-              "required": false,
-              "description": "Use WP Query arguments to modify the response; private query vars require appropriate authorization."
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "any"
+                ],
+                "type": "string"
+              }
             },
             "categories": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to all items that have the specified term assigned in the categories taxonomy."
+              "description": "Limit result set to all items that have the specified term assigned in the categories taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "categories_exclude": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Limit result set to all items except those that have the specified term assigned in the categories taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "tags": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to all items that have the specified term assigned in the tags taxonomy."
+              "description": "Limit result set to all items that have the specified term assigned in the tags taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "tags_exclude": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Limit result set to all items except those that have the specified term assigned in the tags taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "sticky": {
+              "required": false,
+              "description": "Limit result set to items that are sticky.",
+              "type": "boolean"
             }
           }
         },
@@ -134,19 +218,18 @@
           "args": {
             "date": {
               "required": false,
-              "description": "The date the object was published, in the site's timezone."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published, as GMT."
-            },
-            "password": {
-              "required": false,
-              "description": "A password to protect access to the post."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the object unique to its type."
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
             },
             "status": {
               "required": false,
@@ -157,27 +240,38 @@
                 "pending",
                 "private"
               ],
-              "description": "A named status for the object."
+              "description": "A named status for the object.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string"
             },
             "title": {
               "required": false,
-              "description": "The title for the object."
+              "description": "The title for the object.",
+              "type": "object"
             },
             "content": {
               "required": false,
-              "description": "The content for the object."
+              "description": "The content for the object.",
+              "type": "object"
             },
             "author": {
               "required": false,
-              "description": "The id for the author of the object."
+              "description": "The ID for the author of the object.",
+              "type": "integer"
             },
             "excerpt": {
               "required": false,
-              "description": "The excerpt for the object."
+              "description": "The excerpt for the object.",
+              "type": "object"
             },
             "featured_media": {
               "required": false,
-              "description": "The id of the featured media for the object."
+              "description": "The ID of the featured media for the object.",
+              "type": "integer"
             },
             "comment_status": {
               "required": false,
@@ -185,7 +279,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not comments are open on the object."
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
             },
             "ping_status": {
               "required": false,
@@ -193,7 +288,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not the object can be pinged."
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
             },
             "format": {
               "required": false,
@@ -209,19 +305,39 @@
                 "video",
                 "audio"
               ],
-              "description": "The format for the object."
+              "description": "The format for the object.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             },
             "sticky": {
               "required": false,
-              "description": "Whether or not the object should be treated as sticky."
+              "description": "Whether or not the object should be treated as sticky.",
+              "type": "boolean"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
             },
             "categories": {
               "required": false,
-              "description": "The terms assigned to the object in the category taxonomy."
+              "description": "The terms assigned to the object in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "tags": {
               "required": false,
-              "description": "The terms assigned to the object in the post_tag taxonomy."
+              "description": "The terms assigned to the object in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             }
           }
         }
@@ -319,13 +435,6 @@
             ],
             "readonly": true
           },
-          "password": {
-            "description": "A password to protect access to the post.",
-            "type": "string",
-            "context": [
-              "edit"
-            ]
-          },
           "slug": {
             "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
@@ -346,6 +455,7 @@
               "private"
             ],
             "context": [
+              "view",
               "edit"
             ]
           },
@@ -356,6 +466,29 @@
               "view",
               "edit",
               "embed"
+            ],
+            "readonly": true
+          },
+          "password": {
+            "description": "A password to protect access to the content and excerpt.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "permalink_template": {
+            "description": "Permalink template for the object.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "generated_slug": {
+            "description": "Slug automatically generated from the object title.",
+            "type": "string",
+            "context": [
+              "edit"
             ],
             "readonly": true
           },
@@ -410,11 +543,29 @@
                   "edit"
                 ],
                 "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
               }
             }
           },
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -447,15 +598,26 @@
                   "embed"
                 ],
                 "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
               }
             }
           },
           "featured_media": {
-            "description": "The id of the featured media for the object.",
+            "description": "The ID of the featured media for the object.",
             "type": "integer",
             "context": [
               "view",
-              "edit"
+              "edit",
+              "embed"
             ]
           },
           "comment_status": {
@@ -502,6 +664,17 @@
               "edit"
             ]
           },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
+          },
           "sticky": {
             "description": "Whether or not the object should be treated as sticky.",
             "type": "boolean",
@@ -510,9 +683,20 @@
               "edit"
             ]
           },
+          "template": {
+            "description": "The theme file to use to display the object.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
           "categories": {
             "description": "The terms assigned to the object in the category taxonomy.",
             "type": "array",
+            "items": {
+              "type": "integer"
+            },
             "context": [
               "view",
               "edit"
@@ -521,21 +705,139 @@
           "tags": {
             "description": "The terms assigned to the object in the post_tag taxonomy.",
             "type": "array",
+            "items": {
+              "type": "integer"
+            },
             "context": [
               "view",
               "edit"
             ]
-          },
-          "liveblog_likes": {
-            "type": "integer",
-            "description": "The number of Liveblog Likes the post has.",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
           }
-        }
+        },
+        "links": [
+          {
+            "rel": "https://api.w.org/action-publish",
+            "title": "The current user can publish this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "publish",
+                    "future"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-unfiltered-html",
+            "title": "The current user can post unfiltered HTML markup and JavaScript.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "raw": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-sticky",
+            "title": "The current user can sticky this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "sticky": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-author",
+            "title": "The current user can change the author on this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "author": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-categories",
+            "title": "The current user can assign terms in the category taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-create-categories",
+            "title": "The current user can create terms in the category taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-tags",
+            "title": "The current user can assign terms in the post_tag taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-create-tags",
+            "title": "The current user can create terms in the post_tag taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
       "_links": {
         "self": "https://demo.wp-api.org/wp-json/wp/v2/posts"
@@ -557,6 +859,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -565,7 +872,13 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "The password for the post if it is password protected.",
+              "type": "string"
             }
           }
         },
@@ -576,21 +889,25 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "date": {
               "required": false,
-              "description": "The date the object was published, in the site's timezone."
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
             },
             "date_gmt": {
               "required": false,
-              "description": "The date the object was published, as GMT."
-            },
-            "password": {
-              "required": false,
-              "description": "A password to protect access to the post."
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the object unique to its type."
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
             },
             "status": {
               "required": false,
@@ -601,27 +918,38 @@
                 "pending",
                 "private"
               ],
-              "description": "A named status for the object."
+              "description": "A named status for the object.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string"
             },
             "title": {
               "required": false,
-              "description": "The title for the object."
+              "description": "The title for the object.",
+              "type": "object"
             },
             "content": {
               "required": false,
-              "description": "The content for the object."
+              "description": "The content for the object.",
+              "type": "object"
             },
             "author": {
               "required": false,
-              "description": "The id for the author of the object."
+              "description": "The ID for the author of the object.",
+              "type": "integer"
             },
             "excerpt": {
               "required": false,
-              "description": "The excerpt for the object."
+              "description": "The excerpt for the object.",
+              "type": "object"
             },
             "featured_media": {
               "required": false,
-              "description": "The id of the featured media for the object."
+              "description": "The ID of the featured media for the object.",
+              "type": "integer"
             },
             "comment_status": {
               "required": false,
@@ -629,7 +957,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not comments are open on the object."
+              "description": "Whether or not comments are open on the object.",
+              "type": "string"
             },
             "ping_status": {
               "required": false,
@@ -637,7 +966,8 @@
                 "open",
                 "closed"
               ],
-              "description": "Whether or not the object can be pinged."
+              "description": "Whether or not the object can be pinged.",
+              "type": "string"
             },
             "format": {
               "required": false,
@@ -653,19 +983,39 @@
                 "video",
                 "audio"
               ],
-              "description": "The format for the object."
+              "description": "The format for the object.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             },
             "sticky": {
               "required": false,
-              "description": "Whether or not the object should be treated as sticky."
+              "description": "Whether or not the object should be treated as sticky.",
+              "type": "boolean"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
             },
             "categories": {
               "required": false,
-              "description": "The terms assigned to the object in the category taxonomy."
+              "description": "The terms assigned to the object in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "tags": {
               "required": false,
-              "description": "The terms assigned to the object in the post_tag taxonomy."
+              "description": "The terms assigned to the object in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             }
           }
         },
@@ -674,10 +1024,16 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the object.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Whether to bypass trash and force deletion."
+              "description": "Whether to bypass trash and force deletion.",
+              "type": "boolean"
             }
           }
         }
@@ -775,13 +1131,6 @@
             ],
             "readonly": true
           },
-          "password": {
-            "description": "A password to protect access to the post.",
-            "type": "string",
-            "context": [
-              "edit"
-            ]
-          },
           "slug": {
             "description": "An alphanumeric identifier for the object unique to its type.",
             "type": "string",
@@ -802,6 +1151,7 @@
               "private"
             ],
             "context": [
+              "view",
               "edit"
             ]
           },
@@ -812,6 +1162,29 @@
               "view",
               "edit",
               "embed"
+            ],
+            "readonly": true
+          },
+          "password": {
+            "description": "A password to protect access to the content and excerpt.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "permalink_template": {
+            "description": "Permalink template for the object.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "generated_slug": {
+            "description": "Slug automatically generated from the object title.",
+            "type": "string",
+            "context": [
+              "edit"
             ],
             "readonly": true
           },
@@ -866,11 +1239,29 @@
                   "edit"
                 ],
                 "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
               }
             }
           },
           "author": {
-            "description": "The id for the author of the object.",
+            "description": "The ID for the author of the object.",
             "type": "integer",
             "context": [
               "view",
@@ -903,15 +1294,26 @@
                   "embed"
                 ],
                 "readonly": true
+              },
+              "protected": {
+                "description": "Whether the excerpt is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
               }
             }
           },
           "featured_media": {
-            "description": "The id of the featured media for the object.",
+            "description": "The ID of the featured media for the object.",
             "type": "integer",
             "context": [
               "view",
-              "edit"
+              "edit",
+              "embed"
             ]
           },
           "comment_status": {
@@ -958,6 +1360,17 @@
               "edit"
             ]
           },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
+          },
           "sticky": {
             "description": "Whether or not the object should be treated as sticky.",
             "type": "boolean",
@@ -966,9 +1379,20 @@
               "edit"
             ]
           },
+          "template": {
+            "description": "The theme file to use to display the object.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
           "categories": {
             "description": "The terms assigned to the object in the category taxonomy.",
             "type": "array",
+            "items": {
+              "type": "integer"
+            },
             "context": [
               "view",
               "edit"
@@ -977,21 +1401,139 @@
           "tags": {
             "description": "The terms assigned to the object in the post_tag taxonomy.",
             "type": "array",
+            "items": {
+              "type": "integer"
+            },
             "context": [
               "view",
               "edit"
             ]
-          },
-          "liveblog_likes": {
-            "type": "integer",
-            "description": "The number of Liveblog Likes the post has.",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
           }
-        }
+        },
+        "links": [
+          {
+            "rel": "https://api.w.org/action-publish",
+            "title": "The current user can publish this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "publish",
+                    "future"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-unfiltered-html",
+            "title": "The current user can post unfiltered HTML markup and JavaScript.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "raw": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-sticky",
+            "title": "The current user can sticky this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "sticky": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-author",
+            "title": "The current user can change the author on this post.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "author": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-categories",
+            "title": "The current user can assign terms in the category taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-create-categories",
+            "title": "The current user can create terms in the category taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-assign-tags",
+            "title": "The current user can assign terms in the post_tag taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "rel": "https://api.w.org/action-create-tags",
+            "title": "The current user can create terms in the post_tag taxonomy.",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+            "targetSchema": {
+              "type": "object",
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
       "nicename": "/wp/v2/posts/&lt;id&gt;"
     }
@@ -1089,13 +1631,6 @@
         ],
         "readonly": true
       },
-      "password": {
-        "description": "A password to protect access to the post.",
-        "type": "string",
-        "context": [
-          "edit"
-        ]
-      },
       "slug": {
         "description": "An alphanumeric identifier for the object unique to its type.",
         "type": "string",
@@ -1116,6 +1651,7 @@
           "private"
         ],
         "context": [
+          "view",
           "edit"
         ]
       },
@@ -1126,6 +1662,29 @@
           "view",
           "edit",
           "embed"
+        ],
+        "readonly": true
+      },
+      "password": {
+        "description": "A password to protect access to the content and excerpt.",
+        "type": "string",
+        "context": [
+          "edit"
+        ]
+      },
+      "permalink_template": {
+        "description": "Permalink template for the object.",
+        "type": "string",
+        "context": [
+          "edit"
+        ],
+        "readonly": true
+      },
+      "generated_slug": {
+        "description": "Slug automatically generated from the object title.",
+        "type": "string",
+        "context": [
+          "edit"
         ],
         "readonly": true
       },
@@ -1180,11 +1739,29 @@
               "edit"
             ],
             "readonly": true
+          },
+          "block_version": {
+            "description": "Version of the content block format used by the object.",
+            "type": "integer",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the content is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
           }
         }
       },
       "author": {
-        "description": "The id for the author of the object.",
+        "description": "The ID for the author of the object.",
         "type": "integer",
         "context": [
           "view",
@@ -1217,15 +1794,26 @@
               "embed"
             ],
             "readonly": true
+          },
+          "protected": {
+            "description": "Whether the excerpt is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
           }
         }
       },
       "featured_media": {
-        "description": "The id of the featured media for the object.",
+        "description": "The ID of the featured media for the object.",
         "type": "integer",
         "context": [
           "view",
-          "edit"
+          "edit",
+          "embed"
         ]
       },
       "comment_status": {
@@ -1272,6 +1860,17 @@
           "edit"
         ]
       },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
+        ]
+      },
       "sticky": {
         "description": "Whether or not the object should be treated as sticky.",
         "type": "boolean",
@@ -1280,9 +1879,20 @@
           "edit"
         ]
       },
+      "template": {
+        "description": "The theme file to use to display the object.",
+        "type": "string",
+        "context": [
+          "view",
+          "edit"
+        ]
+      },
       "categories": {
         "description": "The terms assigned to the object in the category taxonomy.",
         "type": "array",
+        "items": {
+          "type": "integer"
+        },
         "context": [
           "view",
           "edit"
@@ -1291,20 +1901,138 @@
       "tags": {
         "description": "The terms assigned to the object in the post_tag taxonomy.",
         "type": "array",
+        "items": {
+          "type": "integer"
+        },
         "context": [
           "view",
           "edit"
         ]
-      },
-      "liveblog_likes": {
-        "type": "integer",
-        "description": "The number of Liveblog Likes the post has.",
-        "context": [
-          "view",
-          "edit",
-          "embed"
-        ]
       }
-    }
+    },
+    "links": [
+      {
+        "rel": "https://api.w.org/action-publish",
+        "title": "The current user can publish this post.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "publish",
+                "future"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-unfiltered-html",
+        "title": "The current user can post unfiltered HTML markup and JavaScript.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "content": {
+              "raw": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-sticky",
+        "title": "The current user can sticky this post.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "sticky": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-assign-author",
+        "title": "The current user can change the author on this post.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-assign-categories",
+        "title": "The current user can assign terms in the category taxonomy.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-create-categories",
+        "title": "The current user can create terms in the category taxonomy.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-assign-tags",
+        "title": "The current user can assign terms in the post_tag taxonomy.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      {
+        "rel": "https://api.w.org/action-create-tags",
+        "title": "The current user can create terms in the post_tag taxonomy.",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/posts/{id}",
+        "targetSchema": {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/_data/rendered-block.json
+++ b/_data/rendered-block.json
@@ -1,0 +1,78 @@
+{
+  "name": "rendered-block",
+  "routes": {
+    "/wp/v2/block-renderer/<name>": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "name": {
+              "required": false,
+              "description": "Unique registered name for the block.",
+              "type": "string"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "attributes": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Attributes for core/tag-cloud block",
+              "type": "object"
+            },
+            "post_id": {
+              "required": false,
+              "description": "ID of the post context.",
+              "type": "integer"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/schema#",
+        "title": "rendered-block",
+        "type": "object",
+        "properties": {
+          "rendered": {
+            "description": "The rendered block.",
+            "type": "string",
+            "required": true,
+            "context": [
+              "edit"
+            ]
+          }
+        }
+      },
+      "nicename": "/wp/v2/block-renderer/&lt;name&gt;"
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/schema#",
+    "title": "rendered-block",
+    "type": "object",
+    "properties": {
+      "rendered": {
+        "description": "The rendered block.",
+        "type": "string",
+        "required": true,
+        "context": [
+          "edit"
+        ]
+      }
+    }
+  }
+}

--- a/_data/search-result.json
+++ b/_data/search-result.json
@@ -1,0 +1,194 @@
+{
+  "name": "search-result",
+  "routes": {
+    "/wp/v2/search": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "page": {
+              "required": false,
+              "default": 1,
+              "description": "Current page of the collection.",
+              "type": "integer"
+            },
+            "per_page": {
+              "required": false,
+              "default": 10,
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
+            },
+            "search": {
+              "required": false,
+              "description": "Limit results to those matching a string.",
+              "type": "string"
+            },
+            "type": {
+              "required": false,
+              "default": "post",
+              "enum": [
+                "post"
+              ],
+              "description": "Limit results to items of an object type.",
+              "type": "string"
+            },
+            "subtype": {
+              "required": false,
+              "default": "any",
+              "description": "Limit results to items of one or more object subtypes.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post",
+                  "page",
+                  "any"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "search-result",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "string",
+            "context": [
+              "view",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "url": {
+            "description": "URL to the object.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "view",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "type": {
+            "description": "Object type.",
+            "type": "string",
+            "enum": [
+              "post"
+            ],
+            "context": [
+              "view",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "subtype": {
+            "description": "Object subtype.",
+            "type": "string",
+            "enum": [
+              "post",
+              "page"
+            ],
+            "context": [
+              "view",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "_links": {
+        "self": "https://demo.wp-api.org/wp-json/wp/v2/search"
+      },
+      "nicename": "/wp/v2/search"
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "search-result",
+    "type": "object",
+    "properties": {
+      "id": {
+        "description": "Unique identifier for the object.",
+        "type": "integer",
+        "context": [
+          "view",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "title": {
+        "description": "The title for the object.",
+        "type": "string",
+        "context": [
+          "view",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "url": {
+        "description": "URL to the object.",
+        "type": "string",
+        "format": "uri",
+        "context": [
+          "view",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "type": {
+        "description": "Object type.",
+        "type": "string",
+        "enum": [
+          "post"
+        ],
+        "context": [
+          "view",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "subtype": {
+        "description": "Object subtype.",
+        "type": "string",
+        "enum": [
+          "post",
+          "page"
+        ],
+        "context": [
+          "view",
+          "embed"
+        ],
+        "readonly": true
+      }
+    }
+  }
+}

--- a/_data/settings.json
+++ b/_data/settings.json
@@ -1,0 +1,270 @@
+{
+  "name": "settings",
+  "routes": {
+    "/wp/v2/settings": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": [
+
+          ]
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "title": {
+              "required": false,
+              "description": "Site title.",
+              "type": "string"
+            },
+            "description": {
+              "required": false,
+              "description": "Site tagline.",
+              "type": "string"
+            },
+            "timezone": {
+              "required": false,
+              "description": "A city in the same timezone as you.",
+              "type": "string"
+            },
+            "date_format": {
+              "required": false,
+              "description": "A date format for all date strings.",
+              "type": "string"
+            },
+            "time_format": {
+              "required": false,
+              "description": "A time format for all time strings.",
+              "type": "string"
+            },
+            "start_of_week": {
+              "required": false,
+              "description": "A day number of the week that the week should start on.",
+              "type": "integer"
+            },
+            "language": {
+              "required": false,
+              "description": "WordPress locale code.",
+              "type": "string"
+            },
+            "use_smilies": {
+              "required": false,
+              "description": "Convert emoticons like :-) and :-P to graphics on display.",
+              "type": "boolean"
+            },
+            "default_category": {
+              "required": false,
+              "description": "Default post category.",
+              "type": "integer"
+            },
+            "default_post_format": {
+              "required": false,
+              "description": "Default post format.",
+              "type": "string"
+            },
+            "posts_per_page": {
+              "required": false,
+              "description": "Blog pages show at most.",
+              "type": "integer"
+            },
+            "default_ping_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.",
+              "type": "string"
+            },
+            "default_comment_status": {
+              "required": false,
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "description": "Allow people to post comments on new articles.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "settings",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Site title.",
+            "default": null
+          },
+          "description": {
+            "type": "string",
+            "description": "Site tagline.",
+            "default": null
+          },
+          "timezone": {
+            "type": "string",
+            "description": "A city in the same timezone as you.",
+            "default": null
+          },
+          "date_format": {
+            "type": "string",
+            "description": "A date format for all date strings.",
+            "default": null
+          },
+          "time_format": {
+            "type": "string",
+            "description": "A time format for all time strings.",
+            "default": null
+          },
+          "start_of_week": {
+            "type": "integer",
+            "description": "A day number of the week that the week should start on.",
+            "default": null
+          },
+          "language": {
+            "type": "string",
+            "description": "WordPress locale code.",
+            "default": "en_US"
+          },
+          "use_smilies": {
+            "type": "boolean",
+            "description": "Convert emoticons like :-) and :-P to graphics on display.",
+            "default": true
+          },
+          "default_category": {
+            "type": "integer",
+            "description": "Default post category.",
+            "default": null
+          },
+          "default_post_format": {
+            "type": "string",
+            "description": "Default post format.",
+            "default": null
+          },
+          "posts_per_page": {
+            "type": "integer",
+            "description": "Blog pages show at most.",
+            "default": 10
+          },
+          "default_ping_status": {
+            "type": "string",
+            "description": "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.",
+            "default": null,
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "default_comment_status": {
+            "type": "string",
+            "description": "Allow people to post comments on new articles.",
+            "default": null,
+            "enum": [
+              "open",
+              "closed"
+            ]
+          }
+        }
+      },
+      "_links": {
+        "self": "https://demo.wp-api.org/wp-json/wp/v2/settings"
+      },
+      "nicename": "/wp/v2/settings"
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "settings",
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "Site title.",
+        "default": null
+      },
+      "description": {
+        "type": "string",
+        "description": "Site tagline.",
+        "default": null
+      },
+      "timezone": {
+        "type": "string",
+        "description": "A city in the same timezone as you.",
+        "default": null
+      },
+      "date_format": {
+        "type": "string",
+        "description": "A date format for all date strings.",
+        "default": null
+      },
+      "time_format": {
+        "type": "string",
+        "description": "A time format for all time strings.",
+        "default": null
+      },
+      "start_of_week": {
+        "type": "integer",
+        "description": "A day number of the week that the week should start on.",
+        "default": null
+      },
+      "language": {
+        "type": "string",
+        "description": "WordPress locale code.",
+        "default": "en_US"
+      },
+      "use_smilies": {
+        "type": "boolean",
+        "description": "Convert emoticons like :-) and :-P to graphics on display.",
+        "default": true
+      },
+      "default_category": {
+        "type": "integer",
+        "description": "Default post category.",
+        "default": null
+      },
+      "default_post_format": {
+        "type": "string",
+        "description": "Default post format.",
+        "default": null
+      },
+      "posts_per_page": {
+        "type": "integer",
+        "description": "Blog pages show at most.",
+        "default": 10
+      },
+      "default_ping_status": {
+        "type": "string",
+        "description": "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.",
+        "default": null,
+        "enum": [
+          "open",
+          "closed"
+        ]
+      },
+      "default_comment_status": {
+        "type": "string",
+        "description": "Allow people to post comments on new articles.",
+        "default": null,
+        "enum": [
+          "open",
+          "closed"
+        ]
+      }
+    }
+  }
+}

--- a/_data/status.json
+++ b/_data/status.json
@@ -20,7 +20,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         }
@@ -31,7 +32,7 @@
         "type": "object",
         "properties": {
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the status.",
             "type": "string",
             "context": [
               "embed",
@@ -41,7 +42,7 @@
             "readonly": true
           },
           "private": {
-            "description": "Whether posts with this resource should be private.",
+            "description": "Whether posts with this status should be private.",
             "type": "boolean",
             "context": [
               "edit"
@@ -49,7 +50,7 @@
             "readonly": true
           },
           "protected": {
-            "description": "Whether posts with this resource should be protected.",
+            "description": "Whether posts with this status should be protected.",
             "type": "boolean",
             "context": [
               "edit"
@@ -57,7 +58,7 @@
             "readonly": true
           },
           "public": {
-            "description": "Whether posts of this resource should be shown in the front end of the site.",
+            "description": "Whether posts of this status should be shown in the front end of the site.",
             "type": "boolean",
             "context": [
               "view",
@@ -66,7 +67,7 @@
             "readonly": true
           },
           "queryable": {
-            "description": "Whether posts with this resource should be publicly-queryable.",
+            "description": "Whether posts with this status should be publicly-queryable.",
             "type": "boolean",
             "context": [
               "view",
@@ -83,7 +84,7 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the status.",
             "type": "string",
             "context": [
               "embed",
@@ -110,6 +111,11 @@
             "GET"
           ],
           "args": {
+            "status": {
+              "required": false,
+              "description": "An alphanumeric identifier for the status.",
+              "type": "string"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -118,7 +124,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         }
@@ -129,7 +136,7 @@
         "type": "object",
         "properties": {
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the status.",
             "type": "string",
             "context": [
               "embed",
@@ -139,7 +146,7 @@
             "readonly": true
           },
           "private": {
-            "description": "Whether posts with this resource should be private.",
+            "description": "Whether posts with this status should be private.",
             "type": "boolean",
             "context": [
               "edit"
@@ -147,7 +154,7 @@
             "readonly": true
           },
           "protected": {
-            "description": "Whether posts with this resource should be protected.",
+            "description": "Whether posts with this status should be protected.",
             "type": "boolean",
             "context": [
               "edit"
@@ -155,7 +162,7 @@
             "readonly": true
           },
           "public": {
-            "description": "Whether posts of this resource should be shown in the front end of the site.",
+            "description": "Whether posts of this status should be shown in the front end of the site.",
             "type": "boolean",
             "context": [
               "view",
@@ -164,7 +171,7 @@
             "readonly": true
           },
           "queryable": {
-            "description": "Whether posts with this resource should be publicly-queryable.",
+            "description": "Whether posts with this status should be publicly-queryable.",
             "type": "boolean",
             "context": [
               "view",
@@ -181,7 +188,7 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the status.",
             "type": "string",
             "context": [
               "embed",
@@ -201,7 +208,7 @@
     "type": "object",
     "properties": {
       "name": {
-        "description": "The title for the resource.",
+        "description": "The title for the status.",
         "type": "string",
         "context": [
           "embed",
@@ -211,7 +218,7 @@
         "readonly": true
       },
       "private": {
-        "description": "Whether posts with this resource should be private.",
+        "description": "Whether posts with this status should be private.",
         "type": "boolean",
         "context": [
           "edit"
@@ -219,7 +226,7 @@
         "readonly": true
       },
       "protected": {
-        "description": "Whether posts with this resource should be protected.",
+        "description": "Whether posts with this status should be protected.",
         "type": "boolean",
         "context": [
           "edit"
@@ -227,7 +234,7 @@
         "readonly": true
       },
       "public": {
-        "description": "Whether posts of this resource should be shown in the front end of the site.",
+        "description": "Whether posts of this status should be shown in the front end of the site.",
         "type": "boolean",
         "context": [
           "view",
@@ -236,7 +243,7 @@
         "readonly": true
       },
       "queryable": {
-        "description": "Whether posts with this resource should be publicly-queryable.",
+        "description": "Whether posts with this status should be publicly-queryable.",
         "type": "boolean",
         "context": [
           "view",
@@ -253,7 +260,7 @@
         "readonly": true
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource.",
+        "description": "An alphanumeric identifier for the status.",
         "type": "string",
         "context": [
           "embed",

--- a/_data/tag.json
+++ b/_data/tag.json
@@ -21,39 +21,52 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "offset": {
               "required": false,
-              "description": "Offset the result set by a specific number of items."
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
             },
             "order": {
               "required": false,
@@ -62,7 +75,8 @@
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
@@ -72,24 +86,32 @@
                 "include",
                 "name",
                 "slug",
+                "include_slugs",
                 "term_group",
                 "description",
                 "count"
               ],
-              "description": "Sort collection by resource attribute."
+              "description": "Sort collection by term attribute.",
+              "type": "string"
             },
             "hide_empty": {
               "required": false,
               "default": false,
-              "description": "Whether to hide resources not assigned to any posts."
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean"
             },
             "post": {
               "required": false,
-              "description": "Limit result set to resources assigned to a specific post."
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer"
             },
             "slug": {
               "required": false,
-              "description": "Limit result set to resources with a specific slug."
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
@@ -100,15 +122,23 @@
           "args": {
             "description": {
               "required": false,
-              "description": "HTML description of the resource."
+              "description": "HTML description of the term.",
+              "type": "string"
             },
             "name": {
               "required": true,
-              "description": "HTML title for the resource."
+              "description": "HTML title for the term.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource unique to its type."
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         }
@@ -119,7 +149,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -129,7 +159,7 @@
             "readonly": true
           },
           "count": {
-            "description": "Number of published posts for the resource.",
+            "description": "Number of published posts for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -138,7 +168,7 @@
             "readonly": true
           },
           "description": {
-            "description": "HTML description of the resource.",
+            "description": "HTML description of the term.",
             "type": "string",
             "context": [
               "view",
@@ -146,7 +176,7 @@
             ]
           },
           "link": {
-            "description": "URL to the resource.",
+            "description": "URL of the term.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -157,7 +187,7 @@
             "readonly": true
           },
           "name": {
-            "description": "HTML title for the resource.",
+            "description": "HTML title for the term.",
             "type": "string",
             "context": [
               "view",
@@ -167,7 +197,7 @@
             "required": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource unique to its type.",
+            "description": "An alphanumeric identifier for the term unique to its type.",
             "type": "string",
             "context": [
               "view",
@@ -176,7 +206,7 @@
             ]
           },
           "taxonomy": {
-            "description": "Type attribution for the resource.",
+            "description": "Type attribution for the term.",
             "type": "string",
             "enum": [
               "category",
@@ -191,6 +221,17 @@
               "edit"
             ],
             "readonly": true
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
@@ -214,6 +255,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -222,7 +268,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -233,17 +280,30 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "description": {
               "required": false,
-              "description": "HTML description of the resource."
+              "description": "HTML description of the term.",
+              "type": "string"
             },
             "name": {
               "required": false,
-              "description": "HTML title for the resource."
+              "description": "HTML title for the term.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource unique to its type."
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         },
@@ -252,10 +312,16 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the term.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Required to be true, as resource does not support trashing."
+              "description": "Required to be true, as terms do not support trashing.",
+              "type": "boolean"
             }
           }
         }
@@ -266,7 +332,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -276,7 +342,7 @@
             "readonly": true
           },
           "count": {
-            "description": "Number of published posts for the resource.",
+            "description": "Number of published posts for the term.",
             "type": "integer",
             "context": [
               "view",
@@ -285,7 +351,7 @@
             "readonly": true
           },
           "description": {
-            "description": "HTML description of the resource.",
+            "description": "HTML description of the term.",
             "type": "string",
             "context": [
               "view",
@@ -293,7 +359,7 @@
             ]
           },
           "link": {
-            "description": "URL to the resource.",
+            "description": "URL of the term.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -304,7 +370,7 @@
             "readonly": true
           },
           "name": {
-            "description": "HTML title for the resource.",
+            "description": "HTML title for the term.",
             "type": "string",
             "context": [
               "view",
@@ -314,7 +380,7 @@
             "required": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource unique to its type.",
+            "description": "An alphanumeric identifier for the term unique to its type.",
             "type": "string",
             "context": [
               "view",
@@ -323,7 +389,7 @@
             ]
           },
           "taxonomy": {
-            "description": "Type attribution for the resource.",
+            "description": "Type attribution for the term.",
             "type": "string",
             "enum": [
               "category",
@@ -338,6 +404,17 @@
               "edit"
             ],
             "readonly": true
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
@@ -350,7 +427,7 @@
     "type": "object",
     "properties": {
       "id": {
-        "description": "Unique identifier for the resource.",
+        "description": "Unique identifier for the term.",
         "type": "integer",
         "context": [
           "view",
@@ -360,7 +437,7 @@
         "readonly": true
       },
       "count": {
-        "description": "Number of published posts for the resource.",
+        "description": "Number of published posts for the term.",
         "type": "integer",
         "context": [
           "view",
@@ -369,7 +446,7 @@
         "readonly": true
       },
       "description": {
-        "description": "HTML description of the resource.",
+        "description": "HTML description of the term.",
         "type": "string",
         "context": [
           "view",
@@ -377,7 +454,7 @@
         ]
       },
       "link": {
-        "description": "URL to the resource.",
+        "description": "URL of the term.",
         "type": "string",
         "format": "uri",
         "context": [
@@ -388,7 +465,7 @@
         "readonly": true
       },
       "name": {
-        "description": "HTML title for the resource.",
+        "description": "HTML title for the term.",
         "type": "string",
         "context": [
           "view",
@@ -398,7 +475,7 @@
         "required": true
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource unique to its type.",
+        "description": "An alphanumeric identifier for the term unique to its type.",
         "type": "string",
         "context": [
           "view",
@@ -407,7 +484,7 @@
         ]
       },
       "taxonomy": {
-        "description": "Type attribution for the resource.",
+        "description": "Type attribution for the term.",
         "type": "string",
         "enum": [
           "category",
@@ -422,6 +499,17 @@
           "edit"
         ],
         "readonly": true
+      },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
+        ]
       }
     }
   }

--- a/_data/taxonomy.json
+++ b/_data/taxonomy.json
@@ -20,11 +20,13 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "type": {
               "required": false,
-              "description": "Limit results to resources associated with a specific post type."
+              "description": "Limit results to taxonomies associated with a specific post type.",
+              "type": "string"
             }
           }
         }
@@ -35,15 +37,15 @@
         "type": "object",
         "properties": {
           "capabilities": {
-            "description": "All capabilities used by the resource.",
-            "type": "array",
+            "description": "All capabilities used by the taxonomy.",
+            "type": "object",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "description": {
-            "description": "A human-readable description of the resource.",
+            "description": "A human-readable description of the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -52,7 +54,7 @@
             "readonly": true
           },
           "hierarchical": {
-            "description": "Whether or not the resource should have children.",
+            "description": "Whether or not the taxonomy should have children.",
             "type": "boolean",
             "context": [
               "view",
@@ -61,7 +63,7 @@
             "readonly": true
           },
           "labels": {
-            "description": "Human-readable labels for the resource for various contexts.",
+            "description": "Human-readable labels for the taxonomy for various contexts.",
             "type": "object",
             "context": [
               "edit"
@@ -69,7 +71,7 @@
             "readonly": true
           },
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -79,7 +81,7 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -97,13 +99,60 @@
             "readonly": true
           },
           "types": {
-            "description": "Types associated with resource.",
+            "description": "Types associated with the taxonomy.",
             "type": "array",
+            "items": {
+              "type": "string"
+            },
             "context": [
               "view",
               "edit"
             ],
             "readonly": true
+          },
+          "rest_base": {
+            "description": "REST base route for the taxonomy.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "visibility": {
+            "description": "The visibility settings for the taxonomy.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "public": {
+                "description": "Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
+                "type": "boolean"
+              },
+              "publicly_queryable": {
+                "description": "Whether the taxonomy is publicly queryable.",
+                "type": "boolean"
+              },
+              "show_ui": {
+                "description": "Whether to generate a default UI for managing this taxonomy.",
+                "type": "boolean"
+              },
+              "show_admin_column": {
+                "description": "Whether to allow automatic creation of taxonomy columns on associated post-types table.",
+                "type": "boolean"
+              },
+              "show_in_nav_menus": {
+                "description": "Whether to make the taxonomy available for selection in navigation menus.",
+                "type": "boolean"
+              },
+              "show_in_quick_edit": {
+                "description": "Whether to show the taxonomy in the quick/bulk edit panel.",
+                "type": "boolean"
+              }
+            }
           }
         }
       },
@@ -123,6 +172,11 @@
             "GET"
           ],
           "args": {
+            "taxonomy": {
+              "required": false,
+              "description": "An alphanumeric identifier for the taxonomy.",
+              "type": "string"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -131,7 +185,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         }
@@ -142,15 +197,15 @@
         "type": "object",
         "properties": {
           "capabilities": {
-            "description": "All capabilities used by the resource.",
-            "type": "array",
+            "description": "All capabilities used by the taxonomy.",
+            "type": "object",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "description": {
-            "description": "A human-readable description of the resource.",
+            "description": "A human-readable description of the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -159,7 +214,7 @@
             "readonly": true
           },
           "hierarchical": {
-            "description": "Whether or not the resource should have children.",
+            "description": "Whether or not the taxonomy should have children.",
             "type": "boolean",
             "context": [
               "view",
@@ -168,7 +223,7 @@
             "readonly": true
           },
           "labels": {
-            "description": "Human-readable labels for the resource for various contexts.",
+            "description": "Human-readable labels for the taxonomy for various contexts.",
             "type": "object",
             "context": [
               "edit"
@@ -176,7 +231,7 @@
             "readonly": true
           },
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -186,7 +241,7 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the taxonomy.",
             "type": "string",
             "context": [
               "view",
@@ -204,13 +259,60 @@
             "readonly": true
           },
           "types": {
-            "description": "Types associated with resource.",
+            "description": "Types associated with the taxonomy.",
             "type": "array",
+            "items": {
+              "type": "string"
+            },
             "context": [
               "view",
               "edit"
             ],
             "readonly": true
+          },
+          "rest_base": {
+            "description": "REST base route for the taxonomy.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "visibility": {
+            "description": "The visibility settings for the taxonomy.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "public": {
+                "description": "Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
+                "type": "boolean"
+              },
+              "publicly_queryable": {
+                "description": "Whether the taxonomy is publicly queryable.",
+                "type": "boolean"
+              },
+              "show_ui": {
+                "description": "Whether to generate a default UI for managing this taxonomy.",
+                "type": "boolean"
+              },
+              "show_admin_column": {
+                "description": "Whether to allow automatic creation of taxonomy columns on associated post-types table.",
+                "type": "boolean"
+              },
+              "show_in_nav_menus": {
+                "description": "Whether to make the taxonomy available for selection in navigation menus.",
+                "type": "boolean"
+              },
+              "show_in_quick_edit": {
+                "description": "Whether to show the taxonomy in the quick/bulk edit panel.",
+                "type": "boolean"
+              }
+            }
           }
         }
       },
@@ -223,15 +325,15 @@
     "type": "object",
     "properties": {
       "capabilities": {
-        "description": "All capabilities used by the resource.",
-        "type": "array",
+        "description": "All capabilities used by the taxonomy.",
+        "type": "object",
         "context": [
           "edit"
         ],
         "readonly": true
       },
       "description": {
-        "description": "A human-readable description of the resource.",
+        "description": "A human-readable description of the taxonomy.",
         "type": "string",
         "context": [
           "view",
@@ -240,7 +342,7 @@
         "readonly": true
       },
       "hierarchical": {
-        "description": "Whether or not the resource should have children.",
+        "description": "Whether or not the taxonomy should have children.",
         "type": "boolean",
         "context": [
           "view",
@@ -249,7 +351,7 @@
         "readonly": true
       },
       "labels": {
-        "description": "Human-readable labels for the resource for various contexts.",
+        "description": "Human-readable labels for the taxonomy for various contexts.",
         "type": "object",
         "context": [
           "edit"
@@ -257,7 +359,7 @@
         "readonly": true
       },
       "name": {
-        "description": "The title for the resource.",
+        "description": "The title for the taxonomy.",
         "type": "string",
         "context": [
           "view",
@@ -267,7 +369,7 @@
         "readonly": true
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource.",
+        "description": "An alphanumeric identifier for the taxonomy.",
         "type": "string",
         "context": [
           "view",
@@ -285,13 +387,60 @@
         "readonly": true
       },
       "types": {
-        "description": "Types associated with resource.",
+        "description": "Types associated with the taxonomy.",
         "type": "array",
+        "items": {
+          "type": "string"
+        },
         "context": [
           "view",
           "edit"
         ],
         "readonly": true
+      },
+      "rest_base": {
+        "description": "REST base route for the taxonomy.",
+        "type": "string",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "visibility": {
+        "description": "The visibility settings for the taxonomy.",
+        "type": "object",
+        "context": [
+          "edit"
+        ],
+        "readonly": true,
+        "properties": {
+          "public": {
+            "description": "Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
+            "type": "boolean"
+          },
+          "publicly_queryable": {
+            "description": "Whether the taxonomy is publicly queryable.",
+            "type": "boolean"
+          },
+          "show_ui": {
+            "description": "Whether to generate a default UI for managing this taxonomy.",
+            "type": "boolean"
+          },
+          "show_admin_column": {
+            "description": "Whether to allow automatic creation of taxonomy columns on associated post-types table.",
+            "type": "boolean"
+          },
+          "show_in_nav_menus": {
+            "description": "Whether to make the taxonomy available for selection in navigation menus.",
+            "type": "boolean"
+          },
+          "show_in_quick_edit": {
+            "description": "Whether to show the taxonomy in the quick/bulk edit panel.",
+            "type": "boolean"
+          }
+        }
       }
     }
   }

--- a/_data/theme.json
+++ b/_data/theme.json
@@ -1,0 +1,121 @@
+{
+  "name": "theme",
+  "routes": {
+    "/wp/v2/themes": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "required": false,
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            },
+            "page": {
+              "required": false,
+              "default": 1,
+              "description": "Current page of the collection.",
+              "type": "integer"
+            },
+            "per_page": {
+              "required": false,
+              "default": 10,
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
+            },
+            "search": {
+              "required": false,
+              "description": "Limit results to those matching a string.",
+              "type": "string"
+            },
+            "status": {
+              "required": true,
+              "description": "Limit result set to themes assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "active"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "theme",
+        "type": "object",
+        "properties": {
+          "theme_supports": {
+            "description": "Features supported by this theme.",
+            "type": "array",
+            "readonly": true,
+            "properties": {
+              "formats": {
+                "description": "Post formats supported.",
+                "type": "array",
+                "readonly": true
+              },
+              "post-thumbnails": {
+                "description": "Whether the theme supports post thumbnails.",
+                "type": [
+                  "array",
+                  "bool"
+                ],
+                "readonly": true
+              },
+              "responsive-embeds": {
+                "description": "Whether the theme supports responsive embedded content.",
+                "type": "bool",
+                "readonly": true
+              }
+            }
+          }
+        }
+      },
+      "_links": {
+        "self": "https://demo.wp-api.org/wp-json/wp/v2/themes"
+      },
+      "nicename": "/wp/v2/themes"
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "theme",
+    "type": "object",
+    "properties": {
+      "theme_supports": {
+        "description": "Features supported by this theme.",
+        "type": "array",
+        "readonly": true,
+        "properties": {
+          "formats": {
+            "description": "Post formats supported.",
+            "type": "array",
+            "readonly": true
+          },
+          "post-thumbnails": {
+            "description": "Whether the theme supports post thumbnails.",
+            "type": [
+              "array",
+              "bool"
+            ],
+            "readonly": true
+          },
+          "responsive-embeds": {
+            "description": "Whether the theme supports responsive embedded content.",
+            "type": "bool",
+            "readonly": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/_data/type.json
+++ b/_data/type.json
@@ -20,7 +20,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         }
@@ -31,15 +32,15 @@
         "type": "object",
         "properties": {
           "capabilities": {
-            "description": "All capabilities used by the resource.",
-            "type": "array",
+            "description": "All capabilities used by the post type.",
+            "type": "object",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "description": {
-            "description": "A human-readable description of the resource.",
+            "description": "A human-readable description of the post type.",
             "type": "string",
             "context": [
               "view",
@@ -48,7 +49,7 @@
             "readonly": true
           },
           "hierarchical": {
-            "description": "Whether or not the resource should have children.",
+            "description": "Whether or not the post type should have children.",
             "type": "boolean",
             "context": [
               "view",
@@ -56,8 +57,16 @@
             ],
             "readonly": true
           },
+          "viewable": {
+            "description": "Whether or not the post type can be viewed.",
+            "type": "boolean",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
           "labels": {
-            "description": "Human-readable labels for the resource for various contexts.",
+            "description": "Human-readable labels for the post type for various contexts.",
             "type": "object",
             "context": [
               "edit"
@@ -65,7 +74,7 @@
             "readonly": true
           },
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the post type.",
             "type": "string",
             "context": [
               "view",
@@ -75,7 +84,37 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the post type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "supports": {
+            "description": "All features, supported by the post type.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "taxonomies": {
+            "description": "Taxonomies associated with post type.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "rest_base": {
+            "description": "REST base route for the post type.",
             "type": "string",
             "context": [
               "view",
@@ -102,6 +141,11 @@
             "GET"
           ],
           "args": {
+            "type": {
+              "required": false,
+              "description": "An alphanumeric identifier for the post type.",
+              "type": "string"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -110,7 +154,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         }
@@ -121,15 +166,15 @@
         "type": "object",
         "properties": {
           "capabilities": {
-            "description": "All capabilities used by the resource.",
-            "type": "array",
+            "description": "All capabilities used by the post type.",
+            "type": "object",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "description": {
-            "description": "A human-readable description of the resource.",
+            "description": "A human-readable description of the post type.",
             "type": "string",
             "context": [
               "view",
@@ -138,7 +183,7 @@
             "readonly": true
           },
           "hierarchical": {
-            "description": "Whether or not the resource should have children.",
+            "description": "Whether or not the post type should have children.",
             "type": "boolean",
             "context": [
               "view",
@@ -146,8 +191,16 @@
             ],
             "readonly": true
           },
+          "viewable": {
+            "description": "Whether or not the post type can be viewed.",
+            "type": "boolean",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
           "labels": {
-            "description": "Human-readable labels for the resource for various contexts.",
+            "description": "Human-readable labels for the post type for various contexts.",
             "type": "object",
             "context": [
               "edit"
@@ -155,7 +208,7 @@
             "readonly": true
           },
           "name": {
-            "description": "The title for the resource.",
+            "description": "The title for the post type.",
             "type": "string",
             "context": [
               "view",
@@ -165,7 +218,37 @@
             "readonly": true
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the post type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          },
+          "supports": {
+            "description": "All features, supported by the post type.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "taxonomies": {
+            "description": "Taxonomies associated with post type.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "rest_base": {
+            "description": "REST base route for the post type.",
             "type": "string",
             "context": [
               "view",
@@ -185,15 +268,15 @@
     "type": "object",
     "properties": {
       "capabilities": {
-        "description": "All capabilities used by the resource.",
-        "type": "array",
+        "description": "All capabilities used by the post type.",
+        "type": "object",
         "context": [
           "edit"
         ],
         "readonly": true
       },
       "description": {
-        "description": "A human-readable description of the resource.",
+        "description": "A human-readable description of the post type.",
         "type": "string",
         "context": [
           "view",
@@ -202,7 +285,7 @@
         "readonly": true
       },
       "hierarchical": {
-        "description": "Whether or not the resource should have children.",
+        "description": "Whether or not the post type should have children.",
         "type": "boolean",
         "context": [
           "view",
@@ -210,8 +293,16 @@
         ],
         "readonly": true
       },
+      "viewable": {
+        "description": "Whether or not the post type can be viewed.",
+        "type": "boolean",
+        "context": [
+          "edit"
+        ],
+        "readonly": true
+      },
       "labels": {
-        "description": "Human-readable labels for the resource for various contexts.",
+        "description": "Human-readable labels for the post type for various contexts.",
         "type": "object",
         "context": [
           "edit"
@@ -219,7 +310,7 @@
         "readonly": true
       },
       "name": {
-        "description": "The title for the resource.",
+        "description": "The title for the post type.",
         "type": "string",
         "context": [
           "view",
@@ -229,7 +320,37 @@
         "readonly": true
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource.",
+        "description": "An alphanumeric identifier for the post type.",
+        "type": "string",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ],
+        "readonly": true
+      },
+      "supports": {
+        "description": "All features, supported by the post type.",
+        "type": "object",
+        "context": [
+          "edit"
+        ],
+        "readonly": true
+      },
+      "taxonomies": {
+        "description": "Taxonomies associated with post type.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "context": [
+          "view",
+          "edit"
+        ],
+        "readonly": true
+      },
+      "rest_base": {
+        "description": "REST base route for the post type.",
         "type": "string",
         "context": [
           "view",

--- a/_data/user.json
+++ b/_data/user.json
@@ -21,39 +21,52 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             },
             "page": {
               "required": false,
               "default": 1,
-              "description": "Current page of the collection."
+              "description": "Current page of the collection.",
+              "type": "integer"
             },
             "per_page": {
               "required": false,
               "default": 10,
-              "description": "Maximum number of items to be returned in result set."
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer"
             },
             "search": {
               "required": false,
-              "description": "Limit results to those matching a string."
+              "description": "Limit results to those matching a string.",
+              "type": "string"
             },
             "exclude": {
               "required": false,
               "default": [
 
               ],
-              "description": "Ensure result set excludes specific ids."
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "include": {
               "required": false,
               "default": [
 
               ],
-              "description": "Limit result set to specific ids."
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
             },
             "offset": {
               "required": false,
-              "description": "Offset the result set by a specific number of items."
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer"
             },
             "order": {
               "required": false,
@@ -62,7 +75,8 @@
                 "asc",
                 "desc"
               ],
-              "description": "Order sort attribute ascending or descending."
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string"
             },
             "orderby": {
               "required": false,
@@ -71,17 +85,38 @@
                 "id",
                 "include",
                 "name",
-                "registered_date"
+                "registered_date",
+                "slug",
+                "include_slugs",
+                "email",
+                "url"
               ],
-              "description": "Sort collection by object attribute."
+              "description": "Sort collection by object attribute.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "Limit result set to resources with a specific slug."
+              "description": "Limit result set to users with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "roles": {
               "required": false,
-              "description": "Limit result set to resources matching at least one specific role provided. Accepts csv list or single role."
+              "description": "Limit result set to users matching at least one specific role provided. Accepts csv list or single role.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "who": {
+              "required": false,
+              "enum": [
+                "authors"
+              ],
+              "description": "Limit result set to users who are considered authors.",
+              "type": "string"
             }
           }
         },
@@ -92,47 +127,75 @@
           "args": {
             "username": {
               "required": true,
-              "description": "Login name for the resource."
+              "description": "Login name for the user.",
+              "type": "string"
             },
             "name": {
               "required": false,
-              "description": "Display name for the resource."
+              "description": "Display name for the user.",
+              "type": "string"
             },
             "first_name": {
               "required": false,
-              "description": "First name for the resource."
+              "description": "First name for the user.",
+              "type": "string"
             },
             "last_name": {
               "required": false,
-              "description": "Last name for the resource."
+              "description": "Last name for the user.",
+              "type": "string"
             },
             "email": {
               "required": true,
-              "description": "The email address for the resource."
+              "description": "The email address for the user.",
+              "type": "string"
             },
             "url": {
               "required": false,
-              "description": "URL of the resource."
+              "description": "URL of the user.",
+              "type": "string"
             },
             "description": {
               "required": false,
-              "description": "Description of the resource."
+              "description": "Description of the user.",
+              "type": "string"
+            },
+            "locale": {
+              "required": false,
+              "enum": [
+                "",
+                "en_US"
+              ],
+              "description": "Locale for the user.",
+              "type": "string"
             },
             "nickname": {
               "required": false,
-              "description": "The nickname for the resource."
+              "description": "The nickname for the user.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource."
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string"
             },
             "roles": {
               "required": false,
-              "description": "Roles assigned to the resource."
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "password": {
               "required": true,
-              "description": "Password for the resource (never included)."
+              "description": "Password for the user (never included).",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         }
@@ -143,7 +206,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the user.",
             "type": "integer",
             "context": [
               "embed",
@@ -153,7 +216,7 @@
             "readonly": true
           },
           "username": {
-            "description": "Login name for the resource.",
+            "description": "Login name for the user.",
             "type": "string",
             "context": [
               "edit"
@@ -161,7 +224,7 @@
             "required": true
           },
           "name": {
-            "description": "Display name for the resource.",
+            "description": "Display name for the user.",
             "type": "string",
             "context": [
               "embed",
@@ -170,21 +233,21 @@
             ]
           },
           "first_name": {
-            "description": "First name for the resource.",
+            "description": "First name for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "last_name": {
-            "description": "Last name for the resource.",
+            "description": "Last name for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "email": {
-            "description": "The email address for the resource.",
+            "description": "The email address for the user.",
             "type": "string",
             "format": "email",
             "context": [
@@ -193,7 +256,7 @@
             "required": true
           },
           "url": {
-            "description": "URL of the resource.",
+            "description": "URL of the user.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -203,7 +266,7 @@
             ]
           },
           "description": {
-            "description": "Description of the resource.",
+            "description": "Description of the user.",
             "type": "string",
             "context": [
               "embed",
@@ -212,7 +275,7 @@
             ]
           },
           "link": {
-            "description": "Author URL to the resource.",
+            "description": "Author URL of the user.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -222,15 +285,26 @@
             ],
             "readonly": true
           },
+          "locale": {
+            "description": "Locale for the user.",
+            "type": "string",
+            "enum": [
+              "",
+              "en_US"
+            ],
+            "context": [
+              "edit"
+            ]
+          },
           "nickname": {
-            "description": "The nickname for the resource.",
+            "description": "The nickname for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the user.",
             "type": "string",
             "context": [
               "embed",
@@ -239,22 +313,26 @@
             ]
           },
           "registered_date": {
-            "description": "Registration date for the resource.",
-            "type": "date-time",
+            "description": "Registration date for the user.",
+            "type": "string",
+            "format": "date-time",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "roles": {
-            "description": "Roles assigned to the resource.",
+            "description": "Roles assigned to the user.",
             "type": "array",
+            "items": {
+              "type": "string"
+            },
             "context": [
               "edit"
             ]
           },
           "password": {
-            "description": "Password for the resource (never included).",
+            "description": "Password for the user (never included).",
             "type": "string",
             "context": [
 
@@ -262,7 +340,7 @@
             "required": true
           },
           "capabilities": {
-            "description": "All capabilities assigned to the resource.",
+            "description": "All capabilities assigned to the user.",
             "type": "object",
             "context": [
               "edit"
@@ -270,7 +348,7 @@
             "readonly": true
           },
           "extra_capabilities": {
-            "description": "Any extra capabilities assigned to the resource.",
+            "description": "Any extra capabilities assigned to the user.",
             "type": "object",
             "context": [
               "edit"
@@ -278,7 +356,7 @@
             "readonly": true
           },
           "avatar_urls": {
-            "description": "Avatar URLs for the resource.",
+            "description": "Avatar URLs for the user.",
             "type": "object",
             "context": [
               "embed",
@@ -318,6 +396,17 @@
                 ]
               }
             }
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
@@ -341,6 +430,11 @@
             "GET"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the user.",
+              "type": "integer"
+            },
             "context": {
               "required": false,
               "default": "view",
@@ -349,7 +443,8 @@
                 "embed",
                 "edit"
               ],
-              "description": "Scope under which the request is made; determines fields present in response."
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
             }
           }
         },
@@ -360,49 +455,82 @@
             "PATCH"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the user.",
+              "type": "integer"
+            },
             "username": {
               "required": false,
-              "description": "Login name for the resource."
+              "description": "Login name for the user.",
+              "type": "string"
             },
             "name": {
               "required": false,
-              "description": "Display name for the resource."
+              "description": "Display name for the user.",
+              "type": "string"
             },
             "first_name": {
               "required": false,
-              "description": "First name for the resource."
+              "description": "First name for the user.",
+              "type": "string"
             },
             "last_name": {
               "required": false,
-              "description": "Last name for the resource."
+              "description": "Last name for the user.",
+              "type": "string"
             },
             "email": {
               "required": false,
-              "description": "The email address for the resource."
+              "description": "The email address for the user.",
+              "type": "string"
             },
             "url": {
               "required": false,
-              "description": "URL of the resource."
+              "description": "URL of the user.",
+              "type": "string"
             },
             "description": {
               "required": false,
-              "description": "Description of the resource."
+              "description": "Description of the user.",
+              "type": "string"
+            },
+            "locale": {
+              "required": false,
+              "enum": [
+                "",
+                "en_US"
+              ],
+              "description": "Locale for the user.",
+              "type": "string"
             },
             "nickname": {
               "required": false,
-              "description": "The nickname for the resource."
+              "description": "The nickname for the user.",
+              "type": "string"
             },
             "slug": {
               "required": false,
-              "description": "An alphanumeric identifier for the resource."
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string"
             },
             "roles": {
               "required": false,
-              "description": "Roles assigned to the resource."
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "password": {
               "required": false,
-              "description": "Password for the resource (never included)."
+              "description": "Password for the user (never included).",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
             }
           }
         },
@@ -411,13 +539,21 @@
             "DELETE"
           ],
           "args": {
+            "id": {
+              "required": false,
+              "description": "Unique identifier for the user.",
+              "type": "integer"
+            },
             "force": {
               "required": false,
               "default": false,
-              "description": "Required to be true, as resource does not support trashing."
+              "description": "Required to be true, as users do not support trashing.",
+              "type": "boolean"
             },
             "reassign": {
-              "required": false
+              "required": true,
+              "description": "Reassign the deleted user's posts and links to this user ID.",
+              "type": "integer"
             }
           }
         }
@@ -428,7 +564,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "Unique identifier for the resource.",
+            "description": "Unique identifier for the user.",
             "type": "integer",
             "context": [
               "embed",
@@ -438,7 +574,7 @@
             "readonly": true
           },
           "username": {
-            "description": "Login name for the resource.",
+            "description": "Login name for the user.",
             "type": "string",
             "context": [
               "edit"
@@ -446,7 +582,7 @@
             "required": true
           },
           "name": {
-            "description": "Display name for the resource.",
+            "description": "Display name for the user.",
             "type": "string",
             "context": [
               "embed",
@@ -455,21 +591,21 @@
             ]
           },
           "first_name": {
-            "description": "First name for the resource.",
+            "description": "First name for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "last_name": {
-            "description": "Last name for the resource.",
+            "description": "Last name for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "email": {
-            "description": "The email address for the resource.",
+            "description": "The email address for the user.",
             "type": "string",
             "format": "email",
             "context": [
@@ -478,7 +614,7 @@
             "required": true
           },
           "url": {
-            "description": "URL of the resource.",
+            "description": "URL of the user.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -488,7 +624,7 @@
             ]
           },
           "description": {
-            "description": "Description of the resource.",
+            "description": "Description of the user.",
             "type": "string",
             "context": [
               "embed",
@@ -497,7 +633,7 @@
             ]
           },
           "link": {
-            "description": "Author URL to the resource.",
+            "description": "Author URL of the user.",
             "type": "string",
             "format": "uri",
             "context": [
@@ -507,15 +643,26 @@
             ],
             "readonly": true
           },
+          "locale": {
+            "description": "Locale for the user.",
+            "type": "string",
+            "enum": [
+              "",
+              "en_US"
+            ],
+            "context": [
+              "edit"
+            ]
+          },
           "nickname": {
-            "description": "The nickname for the resource.",
+            "description": "The nickname for the user.",
             "type": "string",
             "context": [
               "edit"
             ]
           },
           "slug": {
-            "description": "An alphanumeric identifier for the resource.",
+            "description": "An alphanumeric identifier for the user.",
             "type": "string",
             "context": [
               "embed",
@@ -524,22 +671,26 @@
             ]
           },
           "registered_date": {
-            "description": "Registration date for the resource.",
-            "type": "date-time",
+            "description": "Registration date for the user.",
+            "type": "string",
+            "format": "date-time",
             "context": [
               "edit"
             ],
             "readonly": true
           },
           "roles": {
-            "description": "Roles assigned to the resource.",
+            "description": "Roles assigned to the user.",
             "type": "array",
+            "items": {
+              "type": "string"
+            },
             "context": [
               "edit"
             ]
           },
           "password": {
-            "description": "Password for the resource (never included).",
+            "description": "Password for the user (never included).",
             "type": "string",
             "context": [
 
@@ -547,7 +698,7 @@
             "required": true
           },
           "capabilities": {
-            "description": "All capabilities assigned to the resource.",
+            "description": "All capabilities assigned to the user.",
             "type": "object",
             "context": [
               "edit"
@@ -555,7 +706,7 @@
             "readonly": true
           },
           "extra_capabilities": {
-            "description": "Any extra capabilities assigned to the resource.",
+            "description": "Any extra capabilities assigned to the user.",
             "type": "object",
             "context": [
               "edit"
@@ -563,7 +714,7 @@
             "readonly": true
           },
           "avatar_urls": {
-            "description": "Avatar URLs for the resource.",
+            "description": "Avatar URLs for the user.",
             "type": "object",
             "context": [
               "embed",
@@ -603,10 +754,364 @@
                 ]
               }
             }
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
           }
         }
       },
       "nicename": "/wp/v2/users/&lt;id&gt;"
+    },
+    "/wp/v2/users/me": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "username": {
+              "required": false,
+              "description": "Login name for the user.",
+              "type": "string"
+            },
+            "name": {
+              "required": false,
+              "description": "Display name for the user.",
+              "type": "string"
+            },
+            "first_name": {
+              "required": false,
+              "description": "First name for the user.",
+              "type": "string"
+            },
+            "last_name": {
+              "required": false,
+              "description": "Last name for the user.",
+              "type": "string"
+            },
+            "email": {
+              "required": false,
+              "description": "The email address for the user.",
+              "type": "string"
+            },
+            "url": {
+              "required": false,
+              "description": "URL of the user.",
+              "type": "string"
+            },
+            "description": {
+              "required": false,
+              "description": "Description of the user.",
+              "type": "string"
+            },
+            "locale": {
+              "required": false,
+              "enum": [
+                "",
+                "en_US"
+              ],
+              "description": "Locale for the user.",
+              "type": "string"
+            },
+            "nickname": {
+              "required": false,
+              "description": "The nickname for the user.",
+              "type": "string"
+            },
+            "slug": {
+              "required": false,
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string"
+            },
+            "roles": {
+              "required": false,
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "password": {
+              "required": false,
+              "description": "Password for the user (never included).",
+              "type": "string"
+            },
+            "meta": {
+              "required": false,
+              "description": "Meta fields.",
+              "type": "object"
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "force": {
+              "required": false,
+              "default": false,
+              "description": "Required to be true, as users do not support trashing.",
+              "type": "boolean"
+            },
+            "reassign": {
+              "required": true,
+              "description": "Reassign the deleted user's posts and links to this user ID.",
+              "type": "integer"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "user",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the user.",
+            "type": "integer",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "username": {
+            "description": "Login name for the user.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "required": true
+          },
+          "name": {
+            "description": "Display name for the user.",
+            "type": "string",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ]
+          },
+          "first_name": {
+            "description": "First name for the user.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "last_name": {
+            "description": "Last name for the user.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "email": {
+            "description": "The email address for the user.",
+            "type": "string",
+            "format": "email",
+            "context": [
+              "edit"
+            ],
+            "required": true
+          },
+          "url": {
+            "description": "URL of the user.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ]
+          },
+          "description": {
+            "description": "Description of the user.",
+            "type": "string",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ]
+          },
+          "link": {
+            "description": "Author URL of the user.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "locale": {
+            "description": "Locale for the user.",
+            "type": "string",
+            "enum": [
+              "",
+              "en_US"
+            ],
+            "context": [
+              "edit"
+            ]
+          },
+          "nickname": {
+            "description": "The nickname for the user.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the user.",
+            "type": "string",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ]
+          },
+          "registered_date": {
+            "description": "Registration date for the user.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "roles": {
+            "description": "Roles assigned to the user.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "context": [
+              "edit"
+            ]
+          },
+          "password": {
+            "description": "Password for the user (never included).",
+            "type": "string",
+            "context": [
+
+            ],
+            "required": true
+          },
+          "capabilities": {
+            "description": "All capabilities assigned to the user.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "extra_capabilities": {
+            "description": "Any extra capabilities assigned to the user.",
+            "type": "object",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "avatar_urls": {
+            "description": "Avatar URLs for the user.",
+            "type": "object",
+            "context": [
+              "embed",
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "24": {
+                "description": "Avatar URL with image size of 24 pixels.",
+                "type": "string",
+                "format": "uri",
+                "context": [
+                  "embed",
+                  "view",
+                  "edit"
+                ]
+              },
+              "48": {
+                "description": "Avatar URL with image size of 48 pixels.",
+                "type": "string",
+                "format": "uri",
+                "context": [
+                  "embed",
+                  "view",
+                  "edit"
+                ]
+              },
+              "96": {
+                "description": "Avatar URL with image size of 96 pixels.",
+                "type": "string",
+                "format": "uri",
+                "context": [
+                  "embed",
+                  "view",
+                  "edit"
+                ]
+              }
+            }
+          },
+          "meta": {
+            "description": "Meta fields.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": [
+
+            ]
+          }
+        }
+      },
+      "_links": {
+        "self": "https://demo.wp-api.org/wp-json/wp/v2/users/me"
+      },
+      "nicename": "/wp/v2/users/me"
     }
   },
   "schema": {
@@ -615,7 +1120,7 @@
     "type": "object",
     "properties": {
       "id": {
-        "description": "Unique identifier for the resource.",
+        "description": "Unique identifier for the user.",
         "type": "integer",
         "context": [
           "embed",
@@ -625,7 +1130,7 @@
         "readonly": true
       },
       "username": {
-        "description": "Login name for the resource.",
+        "description": "Login name for the user.",
         "type": "string",
         "context": [
           "edit"
@@ -633,7 +1138,7 @@
         "required": true
       },
       "name": {
-        "description": "Display name for the resource.",
+        "description": "Display name for the user.",
         "type": "string",
         "context": [
           "embed",
@@ -642,21 +1147,21 @@
         ]
       },
       "first_name": {
-        "description": "First name for the resource.",
+        "description": "First name for the user.",
         "type": "string",
         "context": [
           "edit"
         ]
       },
       "last_name": {
-        "description": "Last name for the resource.",
+        "description": "Last name for the user.",
         "type": "string",
         "context": [
           "edit"
         ]
       },
       "email": {
-        "description": "The email address for the resource.",
+        "description": "The email address for the user.",
         "type": "string",
         "format": "email",
         "context": [
@@ -665,7 +1170,7 @@
         "required": true
       },
       "url": {
-        "description": "URL of the resource.",
+        "description": "URL of the user.",
         "type": "string",
         "format": "uri",
         "context": [
@@ -675,7 +1180,7 @@
         ]
       },
       "description": {
-        "description": "Description of the resource.",
+        "description": "Description of the user.",
         "type": "string",
         "context": [
           "embed",
@@ -684,7 +1189,7 @@
         ]
       },
       "link": {
-        "description": "Author URL to the resource.",
+        "description": "Author URL of the user.",
         "type": "string",
         "format": "uri",
         "context": [
@@ -694,15 +1199,26 @@
         ],
         "readonly": true
       },
+      "locale": {
+        "description": "Locale for the user.",
+        "type": "string",
+        "enum": [
+          "",
+          "en_US"
+        ],
+        "context": [
+          "edit"
+        ]
+      },
       "nickname": {
-        "description": "The nickname for the resource.",
+        "description": "The nickname for the user.",
         "type": "string",
         "context": [
           "edit"
         ]
       },
       "slug": {
-        "description": "An alphanumeric identifier for the resource.",
+        "description": "An alphanumeric identifier for the user.",
         "type": "string",
         "context": [
           "embed",
@@ -711,22 +1227,26 @@
         ]
       },
       "registered_date": {
-        "description": "Registration date for the resource.",
-        "type": "date-time",
+        "description": "Registration date for the user.",
+        "type": "string",
+        "format": "date-time",
         "context": [
           "edit"
         ],
         "readonly": true
       },
       "roles": {
-        "description": "Roles assigned to the resource.",
+        "description": "Roles assigned to the user.",
         "type": "array",
+        "items": {
+          "type": "string"
+        },
         "context": [
           "edit"
         ]
       },
       "password": {
-        "description": "Password for the resource (never included).",
+        "description": "Password for the user (never included).",
         "type": "string",
         "context": [
 
@@ -734,7 +1254,7 @@
         "required": true
       },
       "capabilities": {
-        "description": "All capabilities assigned to the resource.",
+        "description": "All capabilities assigned to the user.",
         "type": "object",
         "context": [
           "edit"
@@ -742,7 +1262,7 @@
         "readonly": true
       },
       "extra_capabilities": {
-        "description": "Any extra capabilities assigned to the resource.",
+        "description": "Any extra capabilities assigned to the user.",
         "type": "object",
         "context": [
           "edit"
@@ -750,7 +1270,7 @@
         "readonly": true
       },
       "avatar_urls": {
-        "description": "Avatar URLs for the resource.",
+        "description": "Avatar URLs for the user.",
         "type": "object",
         "context": [
           "embed",
@@ -790,6 +1310,17 @@
             ]
           }
         }
+      },
+      "meta": {
+        "description": "Meta fields.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": [
+
+        ]
       }
     }
   }

--- a/_data/wp_block-revision.json
+++ b/_data/wp_block-revision.json
@@ -1,0 +1,701 @@
+{
+  "name": "wp_block-revision",
+  "routes": {
+    "/wp/v2/blocks/<id>/autosaves": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "date": {
+              "required": false,
+              "description": "The date the object was published, in the site's timezone.",
+              "type": "string"
+            },
+            "date_gmt": {
+              "required": false,
+              "description": "The date the object was published, as GMT.",
+              "type": "string"
+            },
+            "slug": {
+              "required": false,
+              "description": "An alphanumeric identifier for the object unique to its type.",
+              "type": "string"
+            },
+            "status": {
+              "required": false,
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private"
+              ],
+              "description": "A named status for the object.",
+              "type": "string"
+            },
+            "password": {
+              "required": false,
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string"
+            },
+            "title": {
+              "required": false,
+              "description": "The title for the object.",
+              "type": "object"
+            },
+            "content": {
+              "required": false,
+              "description": "The content for the object.",
+              "type": "object"
+            },
+            "template": {
+              "required": false,
+              "description": "The theme file to use to display the object.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "wp_block-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "nicename": "/wp/v2/blocks/&lt;id&gt;/autosaves"
+    },
+    "/wp/v2/blocks/<parent>/autosaves/<id>": {
+      "namespace": "wp/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "required": false,
+              "description": "The ID for the parent of the object.",
+              "type": "integer"
+            },
+            "id": {
+              "required": false,
+              "description": "The ID for the object.",
+              "type": "integer"
+            },
+            "context": {
+              "required": false,
+              "default": "view",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "wp_block-revision",
+        "type": "object",
+        "properties": {
+          "author": {
+            "description": "The ID for the author of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date": {
+            "description": "The date the object was published, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "date_gmt": {
+            "description": "The date the object was published, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "guid": {
+            "description": "The globally unique identifier for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true,
+            "properties": {
+              "raw": {
+                "description": "GUID for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "rendered": {
+                "description": "GUID for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "modified": {
+            "description": "The date the object was last modified, in the site's timezone.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "modified_gmt": {
+            "description": "The date the object was last modified, as GMT.",
+            "type": "string",
+            "format": "date-time",
+            "context": [
+              "view",
+              "edit"
+            ]
+          },
+          "parent": {
+            "description": "The ID for the parent of the object.",
+            "type": "integer",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "slug": {
+            "description": "An alphanumeric identifier for the object unique to its type.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ]
+          },
+          "title": {
+            "description": "The title for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Title for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML title for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "content": {
+            "description": "The content for the object.",
+            "type": "object",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "properties": {
+              "raw": {
+                "description": "Content for the object, as it exists in the database.",
+                "type": "string",
+                "context": [
+                  "edit"
+                ]
+              },
+              "rendered": {
+                "description": "HTML content for the object, transformed for display.",
+                "type": "string",
+                "context": [
+                  "view",
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "block_version": {
+                "description": "Version of the content block format used by the object.",
+                "type": "integer",
+                "context": [
+                  "edit"
+                ],
+                "readonly": true
+              },
+              "protected": {
+                "description": "Whether the content is protected with a password.",
+                "type": "boolean",
+                "context": [
+                  "view",
+                  "edit",
+                  "embed"
+                ],
+                "readonly": true
+              }
+            }
+          },
+          "preview_link": {
+            "description": "Preview link for the post.",
+            "type": "string",
+            "format": "uri",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "nicename": "/wp/v2/blocks/&lt;parent&gt;/autosaves/&lt;id&gt;"
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "wp_block-revision",
+    "type": "object",
+    "properties": {
+      "author": {
+        "description": "The ID for the author of the object.",
+        "type": "integer",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ]
+      },
+      "date": {
+        "description": "The date the object was published, in the site's timezone.",
+        "type": "string",
+        "format": "date-time",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ]
+      },
+      "date_gmt": {
+        "description": "The date the object was published, as GMT.",
+        "type": "string",
+        "format": "date-time",
+        "context": [
+          "view",
+          "edit"
+        ]
+      },
+      "guid": {
+        "description": "The globally unique identifier for the object.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "readonly": true,
+        "properties": {
+          "raw": {
+            "description": "GUID for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "rendered": {
+            "description": "GUID for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "id": {
+        "description": "Unique identifier for the object.",
+        "type": "integer",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ]
+      },
+      "modified": {
+        "description": "The date the object was last modified, in the site's timezone.",
+        "type": "string",
+        "format": "date-time",
+        "context": [
+          "view",
+          "edit"
+        ]
+      },
+      "modified_gmt": {
+        "description": "The date the object was last modified, as GMT.",
+        "type": "string",
+        "format": "date-time",
+        "context": [
+          "view",
+          "edit"
+        ]
+      },
+      "parent": {
+        "description": "The ID for the parent of the object.",
+        "type": "integer",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ]
+      },
+      "slug": {
+        "description": "An alphanumeric identifier for the object unique to its type.",
+        "type": "string",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ]
+      },
+      "title": {
+        "description": "The title for the object.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit",
+          "embed"
+        ],
+        "properties": {
+          "raw": {
+            "description": "Title for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML title for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "content": {
+        "description": "The content for the object.",
+        "type": "object",
+        "context": [
+          "view",
+          "edit"
+        ],
+        "properties": {
+          "raw": {
+            "description": "Content for the object, as it exists in the database.",
+            "type": "string",
+            "context": [
+              "edit"
+            ]
+          },
+          "rendered": {
+            "description": "HTML content for the object, transformed for display.",
+            "type": "string",
+            "context": [
+              "view",
+              "edit"
+            ],
+            "readonly": true
+          },
+          "block_version": {
+            "description": "Version of the content block format used by the object.",
+            "type": "integer",
+            "context": [
+              "edit"
+            ],
+            "readonly": true
+          },
+          "protected": {
+            "description": "Whether the content is protected with a password.",
+            "type": "boolean",
+            "context": [
+              "view",
+              "edit",
+              "embed"
+            ],
+            "readonly": true
+          }
+        }
+      },
+      "preview_link": {
+        "description": "Preview link for the post.",
+        "type": "string",
+        "format": "uri",
+        "context": [
+          "edit"
+        ],
+        "readonly": true
+      }
+    }
+  }
+}

--- a/_data/wp_block.json
+++ b/_data/wp_block.json
@@ -1,7 +1,7 @@
 {
-  "name": "page",
+  "name": "wp_block",
   "routes": {
-    "/wp/v2/pages": {
+    "/wp/v2/blocks": {
       "namespace": "wp/v2",
       "methods": [
         "GET",
@@ -46,28 +46,6 @@
               "description": "Limit response to posts published after a given ISO8601 compliant date.",
               "type": "string"
             },
-            "author": {
-              "required": false,
-              "default": [
-
-              ],
-              "description": "Limit result set to posts assigned to specific authors.",
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            },
-            "author_exclude": {
-              "required": false,
-              "default": [
-
-              ],
-              "description": "Ensure result set excludes posts assigned to specific authors.",
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            },
             "before": {
               "required": false,
               "description": "Limit response to posts published before a given ISO8601 compliant date.",
@@ -94,11 +72,6 @@
               "items": {
                 "type": "integer"
               }
-            },
-            "menu_order": {
-              "required": false,
-              "description": "Limit result set to posts with a specific menu_order value.",
-              "type": "integer"
             },
             "offset": {
               "required": false,
@@ -128,33 +101,10 @@
                 "relevance",
                 "slug",
                 "include_slugs",
-                "title",
-                "menu_order"
+                "title"
               ],
               "description": "Sort collection by object attribute.",
               "type": "string"
-            },
-            "parent": {
-              "required": false,
-              "default": [
-
-              ],
-              "description": "Limit result set to items with particular parent IDs.",
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            },
-            "parent_exclude": {
-              "required": false,
-              "default": [
-
-              ],
-              "description": "Limit result set to all items except those of a particular parent ID.",
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
             },
             "slug": {
               "required": false,
@@ -227,11 +177,6 @@
               "description": "A password to protect access to the content and excerpt.",
               "type": "string"
             },
-            "parent": {
-              "required": false,
-              "description": "The ID for the parent of the object.",
-              "type": "integer"
-            },
             "title": {
               "required": false,
               "description": "The title for the object.",
@@ -240,49 +185,6 @@
             "content": {
               "required": false,
               "description": "The content for the object.",
-              "type": "object"
-            },
-            "author": {
-              "required": false,
-              "description": "The ID for the author of the object.",
-              "type": "integer"
-            },
-            "excerpt": {
-              "required": false,
-              "description": "The excerpt for the object.",
-              "type": "object"
-            },
-            "featured_media": {
-              "required": false,
-              "description": "The ID of the featured media for the object.",
-              "type": "integer"
-            },
-            "comment_status": {
-              "required": false,
-              "enum": [
-                "open",
-                "closed"
-              ],
-              "description": "Whether or not comments are open on the object.",
-              "type": "string"
-            },
-            "ping_status": {
-              "required": false,
-              "enum": [
-                "open",
-                "closed"
-              ],
-              "description": "Whether or not the object can be pinged.",
-              "type": "string"
-            },
-            "menu_order": {
-              "required": false,
-              "description": "The order of the object in relation to other object of its type.",
-              "type": "integer"
-            },
-            "meta": {
-              "required": false,
-              "description": "Meta fields.",
               "type": "object"
             },
             "template": {
@@ -295,7 +197,7 @@
       ],
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "page",
+        "title": "wp_block",
         "type": "object",
         "properties": {
           "date": {
@@ -427,30 +329,6 @@
               "edit"
             ]
           },
-          "permalink_template": {
-            "description": "Permalink template for the object.",
-            "type": "string",
-            "context": [
-              "edit"
-            ],
-            "readonly": true
-          },
-          "generated_slug": {
-            "description": "Slug automatically generated from the object title.",
-            "type": "string",
-            "context": [
-              "edit"
-            ],
-            "readonly": true
-          },
-          "parent": {
-            "description": "The ID for the parent of the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
           "title": {
             "description": "The title for the object.",
             "type": "object",
@@ -464,18 +342,9 @@
                 "description": "Title for the object, as it exists in the database.",
                 "type": "string",
                 "context": [
+                  "view",
                   "edit"
                 ]
-              },
-              "rendered": {
-                "description": "HTML title for the object, transformed for display.",
-                "type": "string",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
               }
             }
           },
@@ -491,17 +360,9 @@
                 "description": "Content for the object, as it exists in the database.",
                 "type": "string",
                 "context": [
-                  "edit"
-                ]
-              },
-              "rendered": {
-                "description": "HTML content for the object, transformed for display.",
-                "type": "string",
-                "context": [
                   "view",
                   "edit"
-                ],
-                "readonly": true
+                ]
               },
               "block_version": {
                 "description": "Version of the content block format used by the object.",
@@ -523,105 +384,6 @@
               }
             }
           },
-          "author": {
-            "description": "The ID for the author of the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
-          },
-          "excerpt": {
-            "description": "The excerpt for the object.",
-            "type": "object",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ],
-            "properties": {
-              "raw": {
-                "description": "Excerpt for the object, as it exists in the database.",
-                "type": "string",
-                "context": [
-                  "edit"
-                ]
-              },
-              "rendered": {
-                "description": "HTML excerpt for the object, transformed for display.",
-                "type": "string",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
-              },
-              "protected": {
-                "description": "Whether the excerpt is protected with a password.",
-                "type": "boolean",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
-              }
-            }
-          },
-          "featured_media": {
-            "description": "The ID of the featured media for the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
-          },
-          "comment_status": {
-            "description": "Whether or not comments are open on the object.",
-            "type": "string",
-            "enum": [
-              "open",
-              "closed"
-            ],
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "ping_status": {
-            "description": "Whether or not the object can be pinged.",
-            "type": "string",
-            "enum": [
-              "open",
-              "closed"
-            ],
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "menu_order": {
-            "description": "The order of the object in relation to other object of its type.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "meta": {
-            "description": "Meta fields.",
-            "type": "object",
-            "context": [
-              "view",
-              "edit"
-            ],
-            "properties": [
-
-            ]
-          },
           "template": {
             "description": "The theme file to use to display the object.",
             "type": "string",
@@ -635,7 +397,7 @@
           {
             "rel": "https://api.w.org/action-publish",
             "title": "The current user can publish this post.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
             "targetSchema": {
               "type": "object",
               "properties": {
@@ -652,7 +414,7 @@
           {
             "rel": "https://api.w.org/action-unfiltered-html",
             "title": "The current user can post unfiltered HTML markup and JavaScript.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
             "targetSchema": {
               "type": "object",
               "properties": {
@@ -663,28 +425,15 @@
                 }
               }
             }
-          },
-          {
-            "rel": "https://api.w.org/action-assign-author",
-            "title": "The current user can change the author on this post.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
-            "targetSchema": {
-              "type": "object",
-              "properties": {
-                "author": {
-                  "type": "integer"
-                }
-              }
-            }
           }
         ]
       },
       "_links": {
-        "self": "https://demo.wp-api.org/wp-json/wp/v2/pages"
+        "self": "https://demo.wp-api.org/wp-json/wp/v2/blocks"
       },
-      "nicename": "/wp/v2/pages"
+      "nicename": "/wp/v2/blocks"
     },
-    "/wp/v2/pages/<id>": {
+    "/wp/v2/blocks/<id>": {
       "namespace": "wp/v2",
       "methods": [
         "GET",
@@ -766,11 +515,6 @@
               "description": "A password to protect access to the content and excerpt.",
               "type": "string"
             },
-            "parent": {
-              "required": false,
-              "description": "The ID for the parent of the object.",
-              "type": "integer"
-            },
             "title": {
               "required": false,
               "description": "The title for the object.",
@@ -779,49 +523,6 @@
             "content": {
               "required": false,
               "description": "The content for the object.",
-              "type": "object"
-            },
-            "author": {
-              "required": false,
-              "description": "The ID for the author of the object.",
-              "type": "integer"
-            },
-            "excerpt": {
-              "required": false,
-              "description": "The excerpt for the object.",
-              "type": "object"
-            },
-            "featured_media": {
-              "required": false,
-              "description": "The ID of the featured media for the object.",
-              "type": "integer"
-            },
-            "comment_status": {
-              "required": false,
-              "enum": [
-                "open",
-                "closed"
-              ],
-              "description": "Whether or not comments are open on the object.",
-              "type": "string"
-            },
-            "ping_status": {
-              "required": false,
-              "enum": [
-                "open",
-                "closed"
-              ],
-              "description": "Whether or not the object can be pinged.",
-              "type": "string"
-            },
-            "menu_order": {
-              "required": false,
-              "description": "The order of the object in relation to other object of its type.",
-              "type": "integer"
-            },
-            "meta": {
-              "required": false,
-              "description": "Meta fields.",
               "type": "object"
             },
             "template": {
@@ -852,7 +553,7 @@
       ],
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "page",
+        "title": "wp_block",
         "type": "object",
         "properties": {
           "date": {
@@ -984,30 +685,6 @@
               "edit"
             ]
           },
-          "permalink_template": {
-            "description": "Permalink template for the object.",
-            "type": "string",
-            "context": [
-              "edit"
-            ],
-            "readonly": true
-          },
-          "generated_slug": {
-            "description": "Slug automatically generated from the object title.",
-            "type": "string",
-            "context": [
-              "edit"
-            ],
-            "readonly": true
-          },
-          "parent": {
-            "description": "The ID for the parent of the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
           "title": {
             "description": "The title for the object.",
             "type": "object",
@@ -1021,18 +698,9 @@
                 "description": "Title for the object, as it exists in the database.",
                 "type": "string",
                 "context": [
+                  "view",
                   "edit"
                 ]
-              },
-              "rendered": {
-                "description": "HTML title for the object, transformed for display.",
-                "type": "string",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
               }
             }
           },
@@ -1048,17 +716,9 @@
                 "description": "Content for the object, as it exists in the database.",
                 "type": "string",
                 "context": [
-                  "edit"
-                ]
-              },
-              "rendered": {
-                "description": "HTML content for the object, transformed for display.",
-                "type": "string",
-                "context": [
                   "view",
                   "edit"
-                ],
-                "readonly": true
+                ]
               },
               "block_version": {
                 "description": "Version of the content block format used by the object.",
@@ -1080,105 +740,6 @@
               }
             }
           },
-          "author": {
-            "description": "The ID for the author of the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
-          },
-          "excerpt": {
-            "description": "The excerpt for the object.",
-            "type": "object",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ],
-            "properties": {
-              "raw": {
-                "description": "Excerpt for the object, as it exists in the database.",
-                "type": "string",
-                "context": [
-                  "edit"
-                ]
-              },
-              "rendered": {
-                "description": "HTML excerpt for the object, transformed for display.",
-                "type": "string",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
-              },
-              "protected": {
-                "description": "Whether the excerpt is protected with a password.",
-                "type": "boolean",
-                "context": [
-                  "view",
-                  "edit",
-                  "embed"
-                ],
-                "readonly": true
-              }
-            }
-          },
-          "featured_media": {
-            "description": "The ID of the featured media for the object.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ]
-          },
-          "comment_status": {
-            "description": "Whether or not comments are open on the object.",
-            "type": "string",
-            "enum": [
-              "open",
-              "closed"
-            ],
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "ping_status": {
-            "description": "Whether or not the object can be pinged.",
-            "type": "string",
-            "enum": [
-              "open",
-              "closed"
-            ],
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "menu_order": {
-            "description": "The order of the object in relation to other object of its type.",
-            "type": "integer",
-            "context": [
-              "view",
-              "edit"
-            ]
-          },
-          "meta": {
-            "description": "Meta fields.",
-            "type": "object",
-            "context": [
-              "view",
-              "edit"
-            ],
-            "properties": [
-
-            ]
-          },
           "template": {
             "description": "The theme file to use to display the object.",
             "type": "string",
@@ -1192,7 +753,7 @@
           {
             "rel": "https://api.w.org/action-publish",
             "title": "The current user can publish this post.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
             "targetSchema": {
               "type": "object",
               "properties": {
@@ -1209,7 +770,7 @@
           {
             "rel": "https://api.w.org/action-unfiltered-html",
             "title": "The current user can post unfiltered HTML markup and JavaScript.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+            "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
             "targetSchema": {
               "type": "object",
               "properties": {
@@ -1220,28 +781,15 @@
                 }
               }
             }
-          },
-          {
-            "rel": "https://api.w.org/action-assign-author",
-            "title": "The current user can change the author on this post.",
-            "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
-            "targetSchema": {
-              "type": "object",
-              "properties": {
-                "author": {
-                  "type": "integer"
-                }
-              }
-            }
           }
         ]
       },
-      "nicename": "/wp/v2/pages/&lt;id&gt;"
+      "nicename": "/wp/v2/blocks/&lt;id&gt;"
     }
   },
   "schema": {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "page",
+    "title": "wp_block",
     "type": "object",
     "properties": {
       "date": {
@@ -1373,30 +921,6 @@
           "edit"
         ]
       },
-      "permalink_template": {
-        "description": "Permalink template for the object.",
-        "type": "string",
-        "context": [
-          "edit"
-        ],
-        "readonly": true
-      },
-      "generated_slug": {
-        "description": "Slug automatically generated from the object title.",
-        "type": "string",
-        "context": [
-          "edit"
-        ],
-        "readonly": true
-      },
-      "parent": {
-        "description": "The ID for the parent of the object.",
-        "type": "integer",
-        "context": [
-          "view",
-          "edit"
-        ]
-      },
       "title": {
         "description": "The title for the object.",
         "type": "object",
@@ -1410,18 +934,9 @@
             "description": "Title for the object, as it exists in the database.",
             "type": "string",
             "context": [
+              "view",
               "edit"
             ]
-          },
-          "rendered": {
-            "description": "HTML title for the object, transformed for display.",
-            "type": "string",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ],
-            "readonly": true
           }
         }
       },
@@ -1437,17 +952,9 @@
             "description": "Content for the object, as it exists in the database.",
             "type": "string",
             "context": [
-              "edit"
-            ]
-          },
-          "rendered": {
-            "description": "HTML content for the object, transformed for display.",
-            "type": "string",
-            "context": [
               "view",
               "edit"
-            ],
-            "readonly": true
+            ]
           },
           "block_version": {
             "description": "Version of the content block format used by the object.",
@@ -1469,105 +976,6 @@
           }
         }
       },
-      "author": {
-        "description": "The ID for the author of the object.",
-        "type": "integer",
-        "context": [
-          "view",
-          "edit",
-          "embed"
-        ]
-      },
-      "excerpt": {
-        "description": "The excerpt for the object.",
-        "type": "object",
-        "context": [
-          "view",
-          "edit",
-          "embed"
-        ],
-        "properties": {
-          "raw": {
-            "description": "Excerpt for the object, as it exists in the database.",
-            "type": "string",
-            "context": [
-              "edit"
-            ]
-          },
-          "rendered": {
-            "description": "HTML excerpt for the object, transformed for display.",
-            "type": "string",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ],
-            "readonly": true
-          },
-          "protected": {
-            "description": "Whether the excerpt is protected with a password.",
-            "type": "boolean",
-            "context": [
-              "view",
-              "edit",
-              "embed"
-            ],
-            "readonly": true
-          }
-        }
-      },
-      "featured_media": {
-        "description": "The ID of the featured media for the object.",
-        "type": "integer",
-        "context": [
-          "view",
-          "edit",
-          "embed"
-        ]
-      },
-      "comment_status": {
-        "description": "Whether or not comments are open on the object.",
-        "type": "string",
-        "enum": [
-          "open",
-          "closed"
-        ],
-        "context": [
-          "view",
-          "edit"
-        ]
-      },
-      "ping_status": {
-        "description": "Whether or not the object can be pinged.",
-        "type": "string",
-        "enum": [
-          "open",
-          "closed"
-        ],
-        "context": [
-          "view",
-          "edit"
-        ]
-      },
-      "menu_order": {
-        "description": "The order of the object in relation to other object of its type.",
-        "type": "integer",
-        "context": [
-          "view",
-          "edit"
-        ]
-      },
-      "meta": {
-        "description": "Meta fields.",
-        "type": "object",
-        "context": [
-          "view",
-          "edit"
-        ],
-        "properties": [
-
-        ]
-      },
       "template": {
         "description": "The theme file to use to display the object.",
         "type": "string",
@@ -1581,7 +989,7 @@
       {
         "rel": "https://api.w.org/action-publish",
         "title": "The current user can publish this post.",
-        "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
         "targetSchema": {
           "type": "object",
           "properties": {
@@ -1598,7 +1006,7 @@
       {
         "rel": "https://api.w.org/action-unfiltered-html",
         "title": "The current user can post unfiltered HTML markup and JavaScript.",
-        "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
+        "href": "https://demo.wp-api.org/wp-json/wp/v2/blocks/{id}",
         "targetSchema": {
           "type": "object",
           "properties": {
@@ -1606,19 +1014,6 @@
               "raw": {
                 "type": "string"
               }
-            }
-          }
-        }
-      },
-      {
-        "rel": "https://api.w.org/action-assign-author",
-        "title": "The current user can change the author on this post.",
-        "href": "https://demo.wp-api.org/wp-json/wp/v2/pages/{id}",
-        "targetSchema": {
-          "type": "object",
-          "properties": {
-            "author": {
-              "type": "integer"
             }
           }
         }


### PR DESCRIPTION
This pull request

- regenerates the documentation and fixes broken asset links on https://ja.wp-api.org/reference/
- adds `gem 'redcarpet'` to Gemfile to prevent an error when running jekyll